### PR TITLE
Document session-server dedupe follow-up plan

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -87,6 +87,16 @@ The double-tap is useful for:
 | `q` | Disconnect (leave apps running) |
 | `Q` | Quit and stop all apps |
 
+### Command Palette Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Start or switch to selected app |
+| `x` | Stop selected app |
+| `Ctrl+E` | Edit selected app |
+| `Ctrl+R` | Remove selected app and stop any running instances |
+| `Esc` | Close command palette |
+
 ### MANAGER Mode Shortcuts (layout: zellij)
 
 | Key | Action |

--- a/PLAN-session-server-dedupe.md
+++ b/PLAN-session-server-dedupe.md
@@ -1,0 +1,293 @@
+# Plan: Dedupe Classic/Zellij Session Server Internals
+
+## Context
+
+`src/lib/session-server.ts` currently contains both session-server implementations:
+
+- Classic layout: `startSessionServer()` handles tab-oriented app processes.
+- Zellij layout: `startZellijSessionServer()` handles windows, panes, and pane layout state.
+
+The recent stability pass added:
+
+- `src/lib/session-lifecycle.ts` for classic exit/restart cleanup.
+- `src/lib/list-window.ts` for command palette result windowing.
+- `stop_entry` IPC wiring in `src/lib/ipc.ts`, `src/lib/session-client.ts`, and `src/lib/session-server.ts`.
+
+This follow-up refactor should reduce duplication in `src/lib/session-server.ts` while preserving all public behavior and IPC wire shapes.
+
+## Goals
+
+- [ ] Reduce duplicated socket, PTY lifecycle, output buffering, shutdown, and persistence mechanics.
+- [ ] Keep classic and zellij layout behavior explicit and readable.
+- [ ] Avoid changing `ClientMessage`, `ServerMessage`, config schema, keybindings, session file shape, or user-facing behavior.
+- [ ] Improve testability of session-server internals before any larger feature work.
+
+## Non-Goals
+
+- [ ] Do not redesign classic or zellij UX.
+- [ ] Do not change `src/lib/ipc.ts` message names or payloads.
+- [ ] Do not rewrite the whole server into a generic framework.
+- [ ] Do not alter session persistence semantics beyond preserving current behavior.
+
+## Relevant Code References
+
+| Area | Current Files |
+|---|---|
+| Session orchestration | `src/lib/session-server.ts` |
+| IPC types and framing | `src/lib/ipc.ts` |
+| Client commands | `src/lib/session-client.ts` |
+| PTY spawning | `src/lib/pty.ts` |
+| Session persistence | `src/lib/session.ts` |
+| Layout tree helpers | `src/lib/layout.ts` |
+| Runtime/shared types | `src/types/index.ts` |
+| Existing restart helper | `src/lib/session-lifecycle.ts` |
+| Existing tests | `src/lib/session.test.ts`, `src/lib/session-lifecycle.test.ts` |
+
+No external research is required.
+
+## Proposed Module Boundaries
+
+### 1. Shared Socket Server
+
+Create `src/lib/session-socket-server.ts`.
+
+Responsibilities:
+
+- [ ] Own `ensureSocketDir()` and stale `SOCKET_PATH` unlink before listen.
+- [ ] Create the `net.Server`.
+- [ ] Track connected clients.
+- [ ] Parse newline-delimited JSON messages.
+- [ ] Send parse errors as `{ type: "error", message }`.
+- [ ] Broadcast serialized `ServerMessage` values to all live clients.
+- [ ] Clean up client references on `close` and `error`.
+- [ ] Register best-effort socket unlink on `process.on("exit")`.
+
+Suggested interface:
+
+```ts
+interface SessionSocketServerOptions {
+  onClientConnect: (socket: net.Socket) => void
+  onMessage: (message: ClientMessage, socket: net.Socket) => void
+}
+
+interface SessionSocketServer {
+  server: net.Server
+  clients: Set<net.Socket>
+  broadcast: (message: ServerMessage) => void
+  closeClients: () => void
+  closeServer: () => Promise<void>
+  unlinkSocket: () => Promise<void>
+}
+```
+
+Validation:
+
+- [ ] Existing snapshot-on-connect behavior still comes from each layout implementation through `onClientConnect`.
+- [ ] Malformed JSON still returns an `error` server message.
+- [ ] `bun run typecheck` confirms `ClientMessage`/`ServerMessage` stay unchanged.
+
+### 2. Shared Persistence Debounce
+
+Create `src/lib/session-persistence.ts`.
+
+Responsibilities:
+
+- [ ] Encapsulate `persistTimer`, `persistPromise`, `suppressSessionUpdates`, and `shuttingDown` checks.
+- [ ] Provide `persistIfNeeded()` with the current 100ms debounce behavior.
+- [ ] Provide `flushOrPersistOnShutdown(clearSession)` behavior that matches current classic/zellij shutdown branches.
+
+Suggested interface:
+
+```ts
+interface SessionPersistenceController {
+  persistIfNeeded: () => void
+  flushForShutdown: (options?: { clearSession?: boolean }) => Promise<void>
+  suppress: () => void
+  cancelPendingTimer: () => void
+}
+```
+
+Layout-specific code should provide the snapshot writer:
+
+```ts
+type PersistSession = () => Promise<void>
+```
+
+Validation:
+
+- [ ] Classic session files still contain `runningApps`, `activeTab`, and `timestamp`.
+- [ ] Zellij session files still contain `runningApps`, `activeTab`, `windows`, `panes`, `activeWindowId`, `activePaneId`, and `timestamp`.
+- [ ] `src/lib/session.test.ts` remains green.
+
+### 3. Shared PTY Runtime Helper
+
+Create `src/lib/session-runtime.ts`.
+
+Responsibilities:
+
+- [ ] Define reusable `PendingOutput`.
+- [ ] Define a generic `RunningProcess` shape compatible with classic apps and zellij panes.
+- [ ] Encapsulate output buffering with `MAX_BUFFER_CHARS = 200_000`.
+- [ ] Encapsulate pending-output flush timer setup.
+- [ ] Encapsulate manual-stop tracking by `runId`.
+- [ ] Expose helper functions for common stop/kill/resize mechanics.
+
+Keep identity layout-specific:
+
+- Classic process key: app entry id.
+- Zellij process key: pane id.
+
+Suggested interface:
+
+```ts
+interface RunningProcess {
+  entry: AppEntry
+  restartEntry: AppEntry
+  pty: PtyProcess
+  status: AppStatus
+  buffer: string
+  runId: number
+}
+
+interface RuntimeOutputController<Key extends string> {
+  pendingOutputs: Map<Key, PendingOutput>
+  flushOutput: (key: Key) => void
+}
+```
+
+Validation:
+
+- [ ] Classic still emits `output`, `started`, `stopped`, and `status`.
+- [ ] Zellij still emits `pane_output`, `pane_started`, `pane_stopped`, and `pane_status`.
+- [ ] Buffer truncation remains `200_000` chars.
+- [ ] `restart_on_exit` remains covered by `src/lib/session-lifecycle.test.ts`.
+
+### 4. Keep Layout Controllers Separate
+
+After extracting shared mechanics, leave two layout-specific controllers inside `src/lib/session-server.ts` or move them to:
+
+- `src/lib/session-classic-server.ts`
+- `src/lib/session-zellij-server.ts`
+
+Recommended final shape:
+
+```ts
+// src/lib/session-server.ts
+export async function startSessionServer(layoutOverride?: LayoutMode): Promise<void> {
+  const { config } = await loadConfig()
+  if (layoutOverride) config.layout = layoutOverride
+  if (config.layout === "zellij") {
+    await startZellijSessionServer(config)
+    return
+  }
+  await startClassicSessionServer(config)
+}
+```
+
+Classic should continue to own:
+
+- [ ] `runningApps`
+- [ ] `activeTabId`
+- [ ] classic snapshots
+- [ ] classic message handling: `start`, `stop`, `stop_all`, `stop_entry`, `restart`, `input`, `resize`, `set_active`, `update_entry`, `shutdown`
+
+Zellij should continue to own:
+
+- [ ] `runningPanes`
+- [ ] `windows`
+- [ ] `activeWindowId`
+- [ ] `activePaneId`
+- [ ] `lastPaneSizes`
+- [ ] window/pane layout mutations
+- [ ] zellij message handling: `create_window`, `split_pane`, `close_pane`, `close_window`, `stop_entry`, `set_active_window`, `set_active_pane`, `resize_pane`, `input`, `shutdown`
+
+## Implementation Order
+
+### Milestone 1: Extract Socket Plumbing
+
+- [ ] Add `src/lib/session-socket-server.ts`.
+- [ ] Move socket setup, stale unlink, message parsing, broadcast, client cleanup, and close helpers out of `src/lib/session-server.ts`.
+- [ ] Update classic and zellij server setup to use the shared socket helper.
+- [ ] Keep snapshot creation in each layout controller.
+- [ ] Run:
+
+```bash
+bun run typecheck
+bun test
+```
+
+### Milestone 2: Extract Persistence Debounce
+
+- [ ] Add `src/lib/session-persistence.ts`.
+- [ ] Move debounce state and shutdown flush/clear-session coordination into the helper.
+- [ ] Keep classic/zellij session snapshot construction layout-specific.
+- [ ] Verify `shutdown({ clearSession: true })` still clears persisted state before stopping processes.
+- [ ] Run:
+
+```bash
+bun run typecheck
+bun test
+```
+
+### Milestone 3: Extract Runtime Output/PTY Mechanics
+
+- [ ] Add `src/lib/session-runtime.ts`.
+- [ ] Move `MAX_BUFFER_CHARS`, `PendingOutput`, output buffering, flush timer setup, and shared stop/resize helpers.
+- [ ] Keep classic/zellij event names layout-specific.
+- [ ] Keep `handleClassicRunExit()` in `src/lib/session-lifecycle.ts`.
+- [ ] Add unit tests for buffer truncation and pending-output flush behavior if the helper can be tested synchronously.
+- [ ] Run:
+
+```bash
+bun run typecheck
+bun test
+```
+
+### Milestone 4: Optional Split Into Layout Controllers
+
+- [ ] If `src/lib/session-server.ts` is still too large, move classic logic to `src/lib/session-classic-server.ts`.
+- [ ] Move zellij logic to `src/lib/session-zellij-server.ts`.
+- [ ] Leave `src/lib/session-server.ts` as the dispatch wrapper.
+- [ ] Do not rename exported `startSessionServer()`.
+
+### Milestone 5: Final Validation
+
+- [ ] Run full validation:
+
+```bash
+bun test
+bun run typecheck
+bun run build
+bun dist/index.js --version
+git diff --check
+```
+
+- [ ] Confirm `bun dist/index.js --version` reports the package version from `package.json`.
+- [ ] Confirm no public IPC union members were removed or renamed in `src/lib/ipc.ts`.
+
+## Behavioral Regression Checklist
+
+- [ ] Classic autostart still starts configured `autostart: true` apps.
+- [ ] Classic persisted sessions still restore running apps and active tab.
+- [ ] Classic `restart_on_exit` still restarts failed non-manual exits.
+- [ ] Classic manual stops still do not restart.
+- [ ] Classic `stop_entry` still stops the matching app and clears active tab if needed.
+- [ ] Zellij starts a default shell window when no windows exist.
+- [ ] Zellij persisted windows/panes still restore.
+- [ ] Zellij pane splits and window cycling still work.
+- [ ] Zellij `stop_entry` closes every pane whose `pane.entry.id` matches.
+- [ ] `--shutdown` still stops processes, closes clients, unlinks the socket, and clears persisted session state.
+
+## Risks And Constraints
+
+- [ ] Avoid over-generalizing classic app ids and zellij pane ids into a vague abstraction. Keep the key type explicit at call sites.
+- [ ] Do not centralize layout-specific server messages; shared helpers should expose hooks/callbacks so classic and zellij keep their current event names.
+- [ ] Shutdown ordering matters: persist or clear session first, suppress future session updates, then stop processes and close clients.
+- [ ] Socket cleanup should remain best effort and should not crash the app if unlink fails.
+
+## Completion Criteria
+
+- [ ] `src/lib/session-server.ts` is reduced to layout dispatch plus clear classic/zellij orchestration, or split into small layout controller files.
+- [ ] Shared socket, persistence, and runtime helper modules have targeted tests where practical.
+- [ ] No user-facing behavior, config schema, session file format, or IPC wire shape changes.
+- [ ] Full validation passes.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A centralized TUI management application for running multiple TUI applications i
 - **Embedded Terminals**: Run multiple TUIs in a single window using Ghostty's high-performance terminal emulator.
 - **Tab Management**: Organize and switch between different applications using a vertical sidebar.
 - **Simple Modal Keyboard**: Two modes - TABS mode for navigation and TERMINAL mode for PTY input. Toggle with `Ctrl+A`.
-- **Command Palette**: Quickly search and switch between apps with a fuzzy-search palette (`Space`).
+- **Command Palette**: Quickly search, switch, stop, edit, and remove apps with a fuzzy-search palette (`Space`).
 - **Runtime Management**: Add, edit, and remove application entries directly within the app without restarting.
 - **Session Persistence**: Optional config to remember and restore running applications and the active tab between restarts.
 - **Highly Configurable**: Customize themes and application lists via YAML.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuidoscope",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "A centralized TUI management app for running TUI applications in embedded terminal windows",
   "type": "module",
   "main": "dist/index.js",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -268,12 +268,12 @@ export const App: Component<AppProps> = (props) => {
   }
 
   const handleRemoveApp = async (entry: AppEntry) => {
-    props.sessionClient.stopEntry(entry.id)
-    appsStore.removeEntry(entry.id)
-    tabsStore.removeRunningApp(entry.id)
     if (tabsStore.store.activeTabId === entry.id) {
       setActiveTab(null, { broadcast: true })
     }
+    props.sessionClient.stopEntry(entry.id)
+    appsStore.removeEntry(entry.id)
+    tabsStore.removeRunningApp(entry.id)
     uiStore.closeModal()
 
     const didPersist = await persistAppsConfig()

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -267,6 +267,21 @@ export const App: Component<AppProps> = (props) => {
     void persistAppsConfig()
   }
 
+  const handleRemoveApp = async (entry: AppEntry) => {
+    props.sessionClient.stopEntry(entry.id)
+    appsStore.removeEntry(entry.id)
+    tabsStore.removeRunningApp(entry.id)
+    if (tabsStore.store.activeTabId === entry.id) {
+      setActiveTab(null, { broadcast: true })
+    }
+    uiStore.closeModal()
+
+    const didPersist = await persistAppsConfig()
+    uiStore.showTemporaryMessage(
+      didPersist ? `Removed: ${entry.name}` : `Failed to remove: ${entry.name}`
+    )
+  }
+
   const handleDisconnect = () => {
     if (isDisconnecting()) {
       return
@@ -990,6 +1005,11 @@ export const App: Component<AppProps> = (props) => {
             }
 
             uiStore.closeModal()
+            if (action === "remove") {
+              void handleRemoveApp(entry)
+              return
+            }
+
             if (isZellijLayout()) {
               if (action === "switch") {
                 props.sessionClient.createWindow(entry)

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -3,9 +3,10 @@ import { useKeyboard } from "@opentui/solid"
 import type { AppEntry, ThemeConfig } from "../types"
 import { createAppSearch } from "../lib/fuzzy"
 import { buildEntryCommand } from "../lib/command"
+import { getVisibleWindowOffset } from "../lib/list-window"
 import { DialogBox } from "./DialogBox"
 
-export type CommandAction = "switch" | "start" | "stop" | "restart" | "edit"
+export type CommandAction = "switch" | "start" | "stop" | "restart" | "edit" | "remove"
 export type GlobalAction = { type: "open_theme_picker" }
 
 export interface CommandPaletteProps {
@@ -44,6 +45,7 @@ type ResultItem =
 export const CommandPalette: Component<CommandPaletteProps> = (props) => {
   const [query, setQuery] = createSignal("")
   const [selectedIndex, setSelectedIndex] = createSignal(0)
+  const VISIBLE_RESULTS = 10
 
   const search = createMemo(() => createAppSearch(props.entries))
 
@@ -82,6 +84,14 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
     }
   }
 
+  const visibleOffset = createMemo(() =>
+    getVisibleWindowOffset(selectedIndex(), results().length, VISIBLE_RESULTS)
+  )
+
+  const visibleResults = createMemo(() =>
+    results().slice(visibleOffset(), visibleOffset() + VISIBLE_RESULTS)
+  )
+
   useKeyboard((event) => {
     if (event.name === "escape") {
       props.onClose()
@@ -107,6 +117,15 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
       return
     }
 
+    if ((event.ctrl && event.name === "r") || event.sequence === "\u0012") {
+      const selected = results()[selectedIndex()]
+      if (selected && selected.type === "app") {
+        props.onSelect(selected.item, "remove")
+      }
+      event.preventDefault()
+      return
+    }
+
     if (event.name === "up" || event.name === "k") {
       setSelectedIndex((current) => Math.max(0, current - 1))
       event.preventDefault()
@@ -114,7 +133,8 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
     }
 
     if (event.name === "down" || event.name === "j") {
-      setSelectedIndex((current) => Math.min(results().length - 1, current + 1))
+      const total = results().length
+      setSelectedIndex((current) => total === 0 ? 0 : Math.min(total - 1, current + 1))
       event.preventDefault()
       return
     }
@@ -171,9 +191,10 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
 
       {/* Results list */}
       <box flexDirection="column" flexGrow={1} overflow="hidden">
-        <For each={results().slice(0, 10)}>
+        <For each={visibleResults()}>
           {(result, index) => {
-            const isSelected = () => index() === selectedIndex()
+            const actualIndex = () => visibleOffset() + index()
+            const isSelected = () => actualIndex() === selectedIndex()
             const displayText = () => {
               if (result.type === "command") {
                 return `[Cmd] ${result.command.name}`
@@ -213,7 +234,7 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
       >
         <box height={1}>
           <text fg={props.theme.muted}>
-            Enter:Select | x:Stop | Ctrl+E:Edit | Esc:Close | ↑↓:Navigate
+            Enter:Select | x:Stop | Ctrl+E:Edit | Ctrl+R:Remove | Esc:Close | ↑↓:Navigate
           </text>
         </box>
       </box>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -42,10 +42,12 @@ type ResultItem =
   | { type: "app"; item: AppEntry }
   | { type: "command"; command: CommandEntry }
 
+const VISIBLE_RESULTS = 10
+
 export const CommandPalette: Component<CommandPaletteProps> = (props) => {
   const [query, setQuery] = createSignal("")
   const [selectedIndex, setSelectedIndex] = createSignal(0)
-  const VISIBLE_RESULTS = 10
+  const [visibleOffset, setVisibleOffset] = createSignal(0)
 
   const search = createMemo(() => createAppSearch(props.entries))
 
@@ -83,10 +85,6 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
       props.onSelect(result.item, action)
     }
   }
-
-  const visibleOffset = createMemo(() =>
-    getVisibleWindowOffset(selectedIndex(), results().length, VISIBLE_RESULTS)
-  )
 
   const visibleResults = createMemo(() =>
     results().slice(visibleOffset(), visibleOffset() + VISIBLE_RESULTS)
@@ -145,6 +143,18 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
   createEffect(() => {
     results()
     setSelectedIndex(0)
+  })
+
+  createEffect(() => {
+    const nextOffset = getVisibleWindowOffset(
+      selectedIndex(),
+      results().length,
+      VISIBLE_RESULTS,
+      visibleOffset()
+    )
+    if (nextOffset !== visibleOffset()) {
+      setVisibleOffset(nextOffset)
+    }
   })
 
   return (

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -1,6 +1,7 @@
 /**
  * CLI argument parsing for tuidoscope
  */
+import packageJson from "../../package.json"
 
 export interface CLIOptions {
   help: boolean
@@ -13,7 +14,7 @@ export interface CLIOptions {
   unknown: string[]
 }
 
-const VERSION = "0.1.17"
+const VERSION = packageJson.version
 
 const HELP_TEXT = `tuidoscope - A TUI multiplexer for managing terminal applications
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -8,6 +8,7 @@ function makeConfig(apps: Config["apps"]): Config {
     version: 2,
     theme: defaultTheme,
     tab_width: 20,
+    layout: "classic",
     apps,
     session: { persist: true },
   }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -43,6 +43,7 @@ export type ClientMessage =
   | { type: "start"; entry: AppEntry }
   | { type: "stop"; id: string }
   | { type: "stop_all" }
+  | { type: "stop_entry"; id: string }
   | { type: "restart"; entry: AppEntry }
   | { type: "input"; id: string; data: string }
   | { type: "resize"; cols: number; rows: number }

--- a/src/lib/list-window.test.ts
+++ b/src/lib/list-window.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { getVisibleWindowOffset } from "./list-window"
+
+describe("getVisibleWindowOffset", () => {
+  test("keeps early selections at the start", () => {
+    expect(getVisibleWindowOffset(0, 20, 10)).toBe(0)
+    expect(getVisibleWindowOffset(9, 20, 10)).toBe(0)
+  })
+
+  test("scrolls just enough to keep the selection visible", () => {
+    expect(getVisibleWindowOffset(10, 20, 10)).toBe(1)
+    expect(getVisibleWindowOffset(15, 20, 10)).toBe(6)
+  })
+
+  test("clamps to the final visible page", () => {
+    expect(getVisibleWindowOffset(99, 20, 10)).toBe(10)
+  })
+})

--- a/src/lib/list-window.test.ts
+++ b/src/lib/list-window.test.ts
@@ -12,6 +12,15 @@ describe("getVisibleWindowOffset", () => {
     expect(getVisibleWindowOffset(15, 20, 10)).toBe(6)
   })
 
+  test("keeps the current offset when the selection remains visible", () => {
+    expect(getVisibleWindowOffset(9, 20, 10, 1)).toBe(1)
+    expect(getVisibleWindowOffset(11, 20, 10, 2)).toBe(2)
+  })
+
+  test("scrolls up only when the selection leaves the visible window", () => {
+    expect(getVisibleWindowOffset(4, 20, 10, 5)).toBe(4)
+  })
+
   test("clamps to the final visible page", () => {
     expect(getVisibleWindowOffset(99, 20, 10)).toBe(10)
   })

--- a/src/lib/list-window.ts
+++ b/src/lib/list-window.ts
@@ -1,0 +1,18 @@
+export function getVisibleWindowOffset(
+  selectedIndex: number,
+  totalItems: number,
+  visibleItems: number
+): number {
+  if (totalItems <= 0 || visibleItems <= 0 || totalItems <= visibleItems) {
+    return 0
+  }
+
+  const clampedIndex = Math.max(0, Math.min(selectedIndex, totalItems - 1))
+  const maxOffset = totalItems - visibleItems
+
+  if (clampedIndex < visibleItems) {
+    return 0
+  }
+
+  return Math.min(clampedIndex - visibleItems + 1, maxOffset)
+}

--- a/src/lib/list-window.ts
+++ b/src/lib/list-window.ts
@@ -1,7 +1,8 @@
 export function getVisibleWindowOffset(
   selectedIndex: number,
   totalItems: number,
-  visibleItems: number
+  visibleItems: number,
+  currentOffset = 0
 ): number {
   if (totalItems <= 0 || visibleItems <= 0 || totalItems <= visibleItems) {
     return 0
@@ -9,10 +10,15 @@ export function getVisibleWindowOffset(
 
   const clampedIndex = Math.max(0, Math.min(selectedIndex, totalItems - 1))
   const maxOffset = totalItems - visibleItems
+  const clampedOffset = Math.max(0, Math.min(currentOffset, maxOffset))
 
-  if (clampedIndex < visibleItems) {
-    return 0
+  if (clampedIndex < clampedOffset) {
+    return clampedIndex
   }
 
-  return Math.min(clampedIndex - visibleItems + 1, maxOffset)
+  if (clampedIndex >= clampedOffset + visibleItems) {
+    return Math.min(clampedIndex - visibleItems + 1, maxOffset)
+  }
+
+  return clampedOffset
 }

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -66,6 +66,10 @@ export class SessionClient extends EventEmitter {
     this.send({ type: "stop_all" })
   }
 
+  stopEntry(id: string) {
+    this.send({ type: "stop_entry", id })
+  }
+
   restart(entry: AppEntry) {
     this.send({ type: "restart", entry })
   }

--- a/src/lib/session-lifecycle.test.ts
+++ b/src/lib/session-lifecycle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { handleClassicRunExit, type ClassicExitedRunState } from "./session-lifecycle"
+
+function makeRun(restartOnExit: boolean): ClassicExitedRunState {
+  return {
+    status: "running",
+    restartEntry: { restartOnExit },
+  }
+}
+
+describe("handleClassicRunExit", () => {
+  test("clears stale running state before auto-restart", () => {
+    const runningApps = new Map([["app-1", makeRun(true)]])
+    const pendingOutputs = new Map([["app-1", { data: "" }]])
+
+    const result = handleClassicRunExit(runningApps, pendingOutputs, "app-1", 1, false)
+
+    expect(result).toEqual({ status: "error", shouldRestart: true })
+    expect(runningApps.has("app-1")).toBe(false)
+    expect(pendingOutputs.has("app-1")).toBe(false)
+  })
+
+  test("preserves manual stops and does not restart", () => {
+    const run = makeRun(true)
+    const runningApps = new Map([["app-1", run]])
+    const pendingOutputs = new Map([["app-1", { data: "" }]])
+
+    const result = handleClassicRunExit(runningApps, pendingOutputs, "app-1", 1, true)
+
+    expect(result).toEqual({ status: "error", shouldRestart: false })
+    expect(runningApps.get("app-1")).toBe(run)
+    expect(pendingOutputs.has("app-1")).toBe(true)
+  })
+
+  test("does not restart successful exits", () => {
+    const run = makeRun(true)
+    const runningApps = new Map([["app-1", run]])
+    const pendingOutputs = new Map([["app-1", { data: "" }]])
+
+    const result = handleClassicRunExit(runningApps, pendingOutputs, "app-1", 0, false)
+
+    expect(result).toEqual({ status: "stopped", shouldRestart: false })
+    expect(runningApps.get("app-1")?.status).toBe("stopped")
+  })
+})

--- a/src/lib/session-lifecycle.ts
+++ b/src/lib/session-lifecycle.ts
@@ -1,0 +1,37 @@
+import type { AppStatus } from "../types"
+
+export interface ClassicExitedRunState {
+  status: AppStatus
+  restartEntry: {
+    restartOnExit: boolean
+  }
+}
+
+export interface ClassicExitResult {
+  status: AppStatus | null
+  shouldRestart: boolean
+}
+
+export function handleClassicRunExit<T extends ClassicExitedRunState, P>(
+  runningApps: Map<string, T>,
+  pendingOutputs: Map<string, P>,
+  id: string,
+  exitCode: number,
+  wasManualStop: boolean
+): ClassicExitResult {
+  const current = runningApps.get(id)
+  if (!current) {
+    return { status: null, shouldRestart: false }
+  }
+
+  const status: AppStatus = exitCode === 0 ? "stopped" : "error"
+  current.status = status
+
+  const shouldRestart = !wasManualStop && current.restartEntry.restartOnExit && exitCode !== 0
+  if (shouldRestart) {
+    runningApps.delete(id)
+    pendingOutputs.delete(id)
+  }
+
+  return { status, shouldRestart }
+}

--- a/src/lib/session-server.ts
+++ b/src/lib/session-server.ts
@@ -22,6 +22,7 @@ import type {
 } from "../types"
 import { generateId } from "./id"
 import { buildSplitNode, collectPaneIds, removePaneLeaf, replacePaneLeaf } from "./layout"
+import { handleClassicRunExit } from "./session-lifecycle"
 
 const MAX_BUFFER_CHARS = 200_000
 
@@ -271,13 +272,18 @@ export async function startSessionServer(layoutOverride?: LayoutMode): Promise<v
         manualStopRuns.delete(runId)
       }
 
-      const current = runningApps.get(entry.id)
-      if (current) {
-        current.status = exitCode === 0 ? "stopped" : "error"
-        broadcast({ type: "status", id: entry.id, status: current.status })
+      const result = handleClassicRunExit(
+        runningApps,
+        pendingOutputs,
+        entry.id,
+        exitCode,
+        wasManualStop
+      )
+      if (result.status) {
+        broadcast({ type: "status", id: entry.id, status: result.status })
       }
 
-      if (!wasManualStop && app.restartEntry.restartOnExit && exitCode !== 0) {
+      if (result.shouldRestart) {
         setTimeout(() => startApp(app.restartEntry), 1000)
       }
     })
@@ -307,6 +313,13 @@ export async function startSessionServer(layoutOverride?: LayoutMode): Promise<v
       stopApp(id)
     }
     updateActiveTab(null)
+  }
+
+  const stopEntry = (id: string) => {
+    stopApp(id)
+    if (activeTabId === id) {
+      updateActiveTab(null)
+    }
   }
 
   const restartApp = (entry: AppEntry) => {
@@ -393,6 +406,9 @@ export async function startSessionServer(layoutOverride?: LayoutMode): Promise<v
         break
       case "stop_all":
         stopAllApps()
+        break
+      case "stop_entry":
+        stopEntry(message.id)
         break
       case "restart":
         restartApp(message.entry)
@@ -876,6 +892,20 @@ async function startZellijSessionServer(config: Config): Promise<void> {
     persistIfNeeded()
   }
 
+  const closeEntryPanes = (entryId: string) => {
+    const paneIds = Array.from(runningPanes.values())
+      .filter((pane) => pane.entry.id === entryId)
+      .map((pane) => pane.paneId)
+
+    for (const paneId of paneIds) {
+      if (findWindowByPane(paneId)) {
+        closePane(paneId)
+      } else {
+        stopPane(paneId)
+      }
+    }
+  }
+
   const resizePane = (paneId: PaneId, cols: number, rows: number) => {
     lastPaneSizes.set(paneId, { cols, rows })
     const pane = runningPanes.get(paneId)
@@ -946,6 +976,9 @@ async function startZellijSessionServer(config: Config): Promise<void> {
         break
       case "close_window":
         closeWindow(message.windowId)
+        break
+      case "stop_entry":
+        closeEntryPanes(message.id)
         break
       case "set_active_window":
         if (message.id) {

--- a/src/stores/apps.test.ts
+++ b/src/stores/apps.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { createAppsStore } from "./apps"
+
+describe("createAppsStore", () => {
+  test("removes app entries by id", () => {
+    const store = createAppsStore([
+      {
+        id: "shell",
+        name: "Shell",
+        command: "bash",
+        cwd: "~",
+      },
+      {
+        id: "btop",
+        name: "btop",
+        command: "btop",
+        cwd: "~",
+      },
+    ])
+
+    store.removeEntry("shell")
+
+    expect(store.store.entries.map((entry) => entry.id)).toEqual(["btop"])
+  })
+})


### PR DESCRIPTION
## Summary
- Added a detailed PLAN for deduplicating classic and zellij session-server internals.
- The plan covers shared socket plumbing, persistence debounce, PTY/runtime helpers, layout boundaries, and regression criteria.
- Kept the refactor scoped to orchestration and helper extraction without changing IPC shapes or user-facing behavior.

## Testing
- Not run (not requested).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers the "remove app" feature end-to-end: a new `stop_entry` IPC message, `handleRemoveApp` in `app.tsx`, a `Ctrl+R` keybinding in the Command Palette, and a scrollable result window backed by the new `list-window.ts` utility. It also extracts classic exit/restart logic into `session-lifecycle.ts`, fixes the hardcoded `VERSION` in `cli.ts` to read from `package.json`, and adds a detailed deduplication plan for future session-server work.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; findings are minor style and ordering suggestions with no definitive runtime breakage.

All findings are P2: a constant placement nit, a UX scroll edge case, and a potential (but not definitive) active-tab broadcast ordering issue in handleRemoveApp that the server's async broadcast ultimately recovers from.

src/app.tsx — activeTabId check ordering in handleRemoveApp.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app.tsx | Adds handleRemoveApp with stop_entry IPC + store cleanup; activeTabId check ordering may silently skip client-side broadcast in some code paths. |
| src/components/CommandPalette.tsx | Adds scrollable results window, Ctrl+R remove action, and "remove" CommandAction type; correctly guards empty-results edge cases. |
| src/lib/list-window.ts | New scroll-windowing utility; logic is correct, minor UX edge case on up-navigation that resets the window to offset 0. |
| src/lib/session-lifecycle.ts | New helper extracting exit/restart logic from session-server; intentionally deletes runningApps entry during restart delay (tested), behaviour is correct. |
| src/lib/session-server.ts | Wires stop_entry for classic (stopEntry) and zellij (closeEntryPanes); handleClassicRunExit refactor is correct and consistent with tests. |
| src/lib/ipc.ts | Adds stop_entry to ClientMessage union; wired correctly in both classic and zellij server handlers. |
| src/lib/cli.ts | VERSION constant now sourced from package.json, eliminating the risk of drift between the two. |
| PLAN-session-server-dedupe.md | Detailed follow-up refactor plan for deduplicating session-server internals; milestones and regression checklist are thorough. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CommandPalette
    participant App
    participant SessionClient
    participant SessionServer

    User->>CommandPalette: Ctrl+R on selected app
    CommandPalette->>App: onSelect(entry, "remove")
    App->>SessionClient: stopEntry(entry.id)
    SessionClient->>SessionServer: { type: "stop_entry", id }
    App->>App: appsStore.removeEntry(entry.id)
    App->>App: tabsStore.removeRunningApp(entry.id)
    App->>App: uiStore.closeModal()
    App->>App: persistAppsConfig()
    App->>App: showTemporaryMessage("Removed: …")

    SessionServer->>SessionServer: stopApp(id) / closeEntryPanes(id)
    SessionServer-->>App: broadcast { type: "stopped", id }
    SessionServer-->>App: broadcast { type: "active_tab", id: null } (if was active)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/CommandPalette.tsx
Line: 48

Comment:
**Module-level constant declared inside component**

`VISIBLE_RESULTS` is a pure compile-time constant but is re-created on every component instantiation. Hoisting it to module scope makes the intent clear and avoids any (minor) reactive overhead.

```suggestion
const VISIBLE_RESULTS = 10

export const CommandPalette: Component<CommandPaletteProps> = (props) => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/list-window.ts
Line: 13-14

Comment:
**Scroll-up threshold jumps to offset 0 when item re-enters the first page**

When navigating up from `selectedIndex = visibleItems` (offset 1) to `selectedIndex = visibleItems - 1`, the condition `clampedIndex < visibleItems` fires and returns 0. The window snaps from `[1, visibleItems]` to `[0, visibleItems - 1]`. The selected item remains visible, so correctness is unaffected, but the abrupt reset on the first upward step may feel jarring if the user has scrolled far down and then presses Up repeatedly. Consider a symmetric approach — `Math.max(0, clampedIndex - visibleItems + 1)` — which keeps the selected item at the bottom of the window on the way down and at the top on the way up. As-is, the current behaviour is still correct and tests pass.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app.tsx
Line: 270-283

Comment:
**Active-tab broadcast may be silently skipped on remove**

`tabsStore.removeRunningApp(entry.id)` is called before the `activeTabId` check. If `removeRunningApp` already clears `activeTabId` internally, the guard `tabsStore.store.activeTabId === entry.id` evaluates to `false` and `setActiveTab(null, { broadcast: true })` is never called from the client side. The server will eventually broadcast `active_tab: null` via `stopEntry → updateActiveTab(null)`, but that path is async and depends on a round-trip. There is a brief window where the UI's `activeTabId` is out of sync. Moving the `activeTabId` comparison before `removeRunningApp` removes this ambiguity:

```ts
if (tabsStore.store.activeTabId === entry.id) {
  setActiveTab(null, { broadcast: true })
}
props.sessionClient.stopEntry(entry.id)
appsStore.removeEntry(entry.id)
tabsStore.removeRunningApp(entry.id)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Document session-server dedupe plan"](https://github.com/shuv1337/tuidoscope/commit/921425a4bff1e67bcf4046f3b2379c48d252a23b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29802555)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->