### PR TITLE
feat: add app deletion with confirmation and ? help cheatsheet

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,8 @@ import { CommandPalette, type GlobalAction } from "./components/CommandPalette"
 import { AddTabModal } from "./components/AddTabModal"
 import { EditAppModal } from "./components/EditAppModal"
 import { ThemePicker } from "./components/ThemePicker"
+import { ConfirmDialog } from "./components/ConfirmDialog"
+import { HelpModal } from "./components/HelpModal"
 
 import { createAppsStore } from "./stores/apps"
 import { createTabsStore } from "./stores/tabs"
@@ -48,6 +50,7 @@ export const App: Component<AppProps> = (props) => {
 
   const [isDisconnecting, setIsDisconnecting] = createSignal(false)
   const [editingEntryId, setEditingEntryId] = createSignal<string | null>(null)
+  const [pendingDeleteId, setPendingDeleteId] = createSignal<string | null>(null)
   const [lastGTime, setLastGTime] = createSignal(0)
   const [currentTheme, setCurrentTheme] = createSignal<ThemeConfig>(props.config.theme)
 
@@ -282,6 +285,33 @@ export const App: Component<AppProps> = (props) => {
     )
   }
 
+  // Ask before deleting: open the confirmation dialog for the given app.
+  const requestDelete = (id: string) => {
+    setPendingDeleteId(id)
+    uiStore.openModal("confirm-delete")
+  }
+
+  const cancelDelete = () => {
+    setPendingDeleteId(null)
+    uiStore.closeModal()
+  }
+
+  const confirmDelete = () => {
+    const id = pendingDeleteId()
+    const entry = id ? appsStore.getEntry(id) : undefined
+    setPendingDeleteId(null)
+    if (entry) {
+      void handleRemoveApp(entry)
+    } else {
+      uiStore.closeModal()
+    }
+  }
+
+  const deletingEntry = createMemo(() => {
+    const id = pendingDeleteId()
+    return id ? appsStore.getEntry(id) : undefined
+  })
+
   const handleDisconnect = () => {
     if (isDisconnecting()) {
       return
@@ -395,6 +425,9 @@ export const App: Component<AppProps> = (props) => {
         if (uiStore.store.activeModal === "edit-app") {
           setEditingEntryId(null)
         }
+        if (uiStore.store.activeModal === "confirm-delete") {
+          setPendingDeleteId(null)
+        }
         uiStore.closeModal()
         event.preventDefault()
       }
@@ -436,6 +469,17 @@ export const App: Component<AppProps> = (props) => {
       } else {
         tabsStore.toggleFocus()
       }
+      event.preventDefault()
+      return
+    }
+
+    // === HELP CHEATSHEET (?) ===
+    // Available from tabs/manager focus, but not while typing into a terminal.
+    const inTerminalFocus = isZellij
+      ? windowsStore.store.focusMode === "terminal"
+      : tabsStore.store.focusMode === "terminal"
+    if (!inTerminalFocus && (event.name === "?" || event.sequence === "?")) {
+      uiStore.openModal("help")
       event.preventDefault()
       return
     }
@@ -1006,7 +1050,7 @@ export const App: Component<AppProps> = (props) => {
 
             uiStore.closeModal()
             if (action === "remove") {
-              void handleRemoveApp(entry)
+              requestDelete(entry.id)
               return
             }
 
@@ -1059,10 +1103,36 @@ export const App: Component<AppProps> = (props) => {
           theme={currentTheme()}
           entry={editingEntry()!}
           onSave={(updates) => handleEditApp(editingEntry()!.id, updates)}
+          onDelete={() => {
+            const id = editingEntry()!.id
+            setEditingEntryId(null)
+            requestDelete(id)
+          }}
           onClose={() => {
             uiStore.closeModal()
             setEditingEntryId(null)
           }}
+        />
+      </Show>
+
+      <Show when={uiStore.store.activeModal === "confirm-delete" && deletingEntry()}>
+        <ConfirmDialog
+          theme={currentTheme()}
+          title="Delete app?"
+          message={`Delete "${deletingEntry()!.name}" from your app list?`}
+          detail="This removes it from your config. (it can be re-added later)"
+          confirmHint="y:Delete"
+          cancelHint="n/Esc:Cancel"
+          onConfirm={confirmDelete}
+          onCancel={cancelDelete}
+        />
+      </Show>
+
+      <Show when={uiStore.store.activeModal === "help"}>
+        <HelpModal
+          theme={currentTheme()}
+          layoutMode={layoutMode()}
+          onClose={() => uiStore.closeModal()}
         />
       </Show>
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -244,7 +244,7 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
       >
         <box height={1}>
           <text fg={props.theme.muted}>
-            Enter:Select | x:Stop | Ctrl+E:Edit | Ctrl+R:Remove | Esc:Close | ↑↓:Navigate
+            Enter:Select | x:Stop | Ctrl+E:Edit | Ctrl+R:Delete | Esc:Close | ↑↓:Navigate
           </text>
         </box>
       </box>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import { Component } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import type { ThemeConfig } from "../types"
+import { DialogBox } from "./DialogBox"
+
+export interface ConfirmDialogProps {
+  theme: ThemeConfig
+  title: string
+  message: string
+  detail?: string
+  confirmHint?: string
+  cancelHint?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
+  useKeyboard((event) => {
+    // Require an explicit "y" to confirm a destructive action.
+    if (event.name === "y") {
+      props.onConfirm()
+      event.preventDefault()
+      return
+    }
+
+    if (event.name === "n" || event.name === "escape") {
+      props.onCancel()
+      event.preventDefault()
+      return
+    }
+  })
+
+  return (
+    <DialogBox theme={props.theme} top="35%" left="25%" width="50%" height={9}>
+      {/* Title */}
+      <box height={1} paddingLeft={1}>
+        <text fg={props.theme.accent}>
+          <b>{props.title}</b>
+        </text>
+      </box>
+
+      <box height={1} />
+
+      {/* Message */}
+      <box height={1} paddingLeft={1} paddingRight={1}>
+        <text fg={props.theme.foreground}>{props.message}</text>
+      </box>
+
+      {/* Optional detail line */}
+      {props.detail ? (
+        <box height={1} paddingLeft={1} paddingRight={1}>
+          <text fg={props.theme.muted}>{props.detail}</text>
+        </box>
+      ) : null}
+
+      <box flexGrow={1} />
+
+      {/* Footer */}
+      <box height={1} paddingLeft={1}>
+        <text fg={props.theme.muted}>
+          {props.confirmHint ?? "y:Confirm"}
+          {"  |  "}
+          {props.cancelHint ?? "n/Esc:Cancel"}
+        </text>
+      </box>
+    </DialogBox>
+  )
+}

--- a/src/components/EditAppModal.tsx
+++ b/src/components/EditAppModal.tsx
@@ -7,6 +7,7 @@ export interface EditAppModalProps {
   theme: ThemeConfig
   entry: Pick<AppEntry, "id" | "name" | "command" | "args" | "cwd">
   onSave: (updates: { name: string; command: string; args?: string; cwd: string }) => void
+  onDelete: () => void
   onClose: () => void
 }
 
@@ -64,6 +65,13 @@ export const EditAppModal: Component<EditAppModalProps> = (props) => {
       return
     }
 
+    // Ctrl+D: delete this app (parent shows a confirmation first)
+    if ((event.ctrl && event.name === "d") || event.sequence === "\u0004") {
+      props.onDelete()
+      event.preventDefault()
+      return
+    }
+
     const focused = fields[focusIndex()]
     if (!focused) {
       return
@@ -117,7 +125,7 @@ export const EditAppModal: Component<EditAppModalProps> = (props) => {
       {/* Footer */}
       <box height={1}>
         <text fg={props.theme.muted}>
-          Enter:Save | Esc:Cancel | Tab:Next field
+          Enter:Save | Ctrl+D:Delete | Esc:Cancel | Tab:Next field
         </text>
       </box>
     </DialogBox>

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,0 +1,167 @@
+import { Component, For } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import type { LayoutMode, ThemeConfig } from "../types"
+import { DialogBox } from "./DialogBox"
+
+export interface HelpModalProps {
+  theme: ThemeConfig
+  layoutMode?: LayoutMode
+  onClose: () => void
+}
+
+interface Shortcut {
+  keys: string
+  label: string
+}
+
+interface Group {
+  title: string
+  shortcuts: Shortcut[]
+}
+
+const TABS_GROUPS: Group[] = [
+  {
+    title: "Navigate",
+    shortcuts: [
+      { keys: "j / k  ↑ / ↓", label: "Move selection" },
+      { keys: "gg / G", label: "Jump to top / bottom" },
+      { keys: "Enter", label: "Open / select app" },
+      { keys: "Ctrl+A", label: "Toggle terminal focus" },
+    ],
+  },
+  {
+    title: "Manage apps",
+    shortcuts: [
+      { keys: "t", label: "Add new app" },
+      { keys: "e", label: "Edit app  (Ctrl+D deletes)" },
+      { keys: "x", label: "Stop running app" },
+      { keys: "r", label: "Restart running app" },
+      { keys: "K", label: "Kill all apps" },
+      { keys: "Space", label: "Command palette" },
+    ],
+  },
+  {
+    title: "Session",
+    shortcuts: [
+      { keys: "q", label: "Detach session" },
+      { keys: "Q", label: "Quit / shutdown" },
+      { keys: "?", label: "Toggle this help" },
+    ],
+  },
+]
+
+const ZELLIJ_GROUPS: Group[] = [
+  {
+    title: "Panes",
+    shortcuts: [
+      { keys: "v", label: "Split vertical" },
+      { keys: "s", label: "Split horizontal" },
+      { keys: "x", label: "Close pane" },
+      { keys: "p", label: "Next pane" },
+    ],
+  },
+  {
+    title: "Windows",
+    shortcuts: [
+      { keys: "n", label: "New window" },
+      { keys: "w", label: "Close window" },
+      { keys: "[ / ]", label: "Prev / next window" },
+    ],
+  },
+  {
+    title: "General",
+    shortcuts: [
+      { keys: "t", label: "Add new app" },
+      { keys: "Space", label: "Command palette" },
+      { keys: "Ctrl+A", label: "Toggle terminal focus" },
+      { keys: "q / Q", label: "Detach / quit" },
+      { keys: "?", label: "Toggle this help" },
+    ],
+  },
+]
+
+const MODAL_GROUPS: Group[] = [
+  {
+    title: "Command palette",
+    shortcuts: [
+      { keys: "Ctrl+E", label: "Edit selected app" },
+      { keys: "Ctrl+R", label: "Delete selected app" },
+      { keys: "x", label: "Stop selected app" },
+    ],
+  },
+  {
+    title: "Edit app",
+    shortcuts: [
+      { keys: "Ctrl+D", label: "Delete this app" },
+      { keys: "Tab", label: "Next field" },
+    ],
+  },
+]
+
+export const HelpModal: Component<HelpModalProps> = (props) => {
+  useKeyboard((event) => {
+    if (event.name === "escape" || event.name === "?" || event.name === "q") {
+      props.onClose()
+      event.preventDefault()
+    }
+  })
+
+  const primaryGroups = () =>
+    props.layoutMode === "zellij" ? ZELLIJ_GROUPS : TABS_GROUPS
+  const modeLabel = () =>
+    props.layoutMode === "zellij" ? "Manager" : "Tabs"
+
+  return (
+    <DialogBox theme={props.theme} top="8%" left="18%" width="64%" height="84%">
+      {/* Title */}
+      <box height={1} paddingLeft={1} flexDirection="row">
+        <text fg={props.theme.accent}>
+          <b>Keyboard Shortcuts</b>
+        </text>
+        <text fg={props.theme.muted}>{`   (${modeLabel()} mode)`}</text>
+      </box>
+
+      <box height={1} />
+
+      {/* Mode-specific groups */}
+      <For each={primaryGroups()}>
+        {(group) => <ShortcutGroup group={group} theme={props.theme} />}
+      </For>
+
+      {/* Shortcuts that live inside modals */}
+      <For each={MODAL_GROUPS}>
+        {(group) => <ShortcutGroup group={group} theme={props.theme} />}
+      </For>
+
+      <box flexGrow={1} />
+
+      {/* Footer */}
+      <box height={1} paddingLeft={1}>
+        <text fg={props.theme.muted}>?, q or Esc to close</text>
+      </box>
+    </DialogBox>
+  )
+}
+
+const ShortcutGroup: Component<{ group: Group; theme: ThemeConfig }> = (props) => {
+  return (
+    <box flexDirection="column">
+      <box height={1} paddingLeft={1}>
+        <text fg={props.theme.primary}>
+          <b>{props.group.title}</b>
+        </text>
+      </box>
+      <For each={props.group.shortcuts}>
+        {(shortcut) => (
+          <box height={1} flexDirection="row" paddingLeft={2}>
+            <box width={16}>
+              <text fg={props.theme.accent}>{shortcut.keys}</text>
+            </box>
+            <text fg={props.theme.foreground}>{shortcut.label}</text>
+          </box>
+        )}
+      </For>
+      <box height={1} />
+    </box>
+  )
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -31,12 +31,12 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
             when={props.layoutMode === "zellij"}
             fallback={
               <text fg={props.theme.foreground}>
-                {" j/k:Nav  gg/G:Jump  Enter:Select  Space:Palette  t:New  e:Edit  x:Stop  r:Restart  K:KillAll  q:Detach  Q:Quit  Ctrl+A:Terminal"}
+                {" j/k:Nav  Enter:Select  Space:Palette  t:New  e:Edit  Ctrl+A:Terminal  ?:Help"}
               </text>
             }
           >
             <text fg={props.theme.foreground}>
-              {" v:SplitV  s:SplitH  n:NewWin  x:ClosePane  w:CloseWin  [:PrevWin  ]:NextWin  p:NextPane  Space:Palette  Ctrl+A:Terminal"}
+              {" Space:Palette  n:NewWin  v/s:Split  p:NextPane  Ctrl+A:Terminal  ?:Help"}
             </text>
           </Show>
         </Show>

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 
-export type ModalType = "add-tab" | "command-palette" | "edit-app" | "theme-picker" | null
+export type ModalType = "add-tab" | "command-palette" | "edit-app" | "theme-picker" | "confirm-delete" | "help" | null
 
 export interface UIStore {
   activeModal: ModalType


### PR DESCRIPTION
Removing an app from the list was only reachable via the command palette's Ctrl+R and ran with no confirmation, making it effectively undiscoverable. Surface it and guard it:

- Ctrl+D in the Edit App modal deletes the app
- New ConfirmDialog gates all deletes (y:Delete / n/Esc:Cancel); both the edit-modal and palette Ctrl+R paths route through it
- New ? cheatsheet (HelpModal) lists all shortcuts grouped by mode
- Trim the status-bar footer to essentials + ?:Help now that the cheatsheet is the canonical keymap reference
- Relabel palette hint Ctrl+R:Remove -> Ctrl+R:Delete