### PR TITLE
fix: correct terminal rendering for full-screen TUIs (btop, Claude Code)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@opentui/core": "^0.1.67",
         "@opentui/solid": "^0.1.67",
         "fuse.js": "^7.0.0",
-        "ghostty-opentui": "^1.3.11",
+        "ghostty-opentui": "1.5.0",
         "solid-js": "^1.9.3",
         "yaml": "^2.6.1",
         "zod": "^3.24.1",
@@ -161,6 +161,8 @@
 
     "@opentui/solid": ["@opentui/solid@0.1.67", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.67", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.9", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.9" } }, "sha512-dVNq0+PJIdNb63D0T7vcbyVF/ZvLCihGvivTU50zDOzd0Sk5prbrIfpG8+DjMErFubXfdZQvdy/PqFdtw0rjtQ=="],
 
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
+
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
@@ -213,11 +215,15 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001762", "", {}, "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw=="],
 
+    "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
@@ -247,7 +253,7 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "ghostty-opentui": ["ghostty-opentui@1.3.11", "", { "dependencies": { "strip-ansi": "^7.1.2" }, "peerDependencies": { "@opentui/core": "*" }, "optionalPeers": ["@opentui/core"] }, "sha512-taKOhQD65dip/GBi2eDicyS6Z+m7T6CAWyUcFUVP3nX+JKTCiOwfncGqhnqtSa8VE3mG6VHaPzIimDVN7pdD6w=="],
+    "ghostty-opentui": ["ghostty-opentui@1.5.0", "", { "dependencies": { "@resvg/resvg-wasm": "^2.6.2", "strip-ansi": "^7.1.2", "wcwidth": "^1.0.1" }, "peerDependencies": { "@opentui/core": "*" }, "optionalPeers": ["@opentui/core"] }, "sha512-1Kux7BjVtCevjz6Y/tsNPahXmEzJwAc3MqbmsX8chO6CybDG8YOna3gVbQuOgBRte4/CxOtGYJ9rgAKpqGKFPA=="],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 
@@ -372,6 +378,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@opentui/core": "^0.1.67",
     "@opentui/solid": "^0.1.67",
     "fuse.js": "^7.0.0",
-    "ghostty-opentui": "^1.3.11",
+    "ghostty-opentui": "1.5.0",
     "solid-js": "^1.9.3",
     "yaml": "^2.6.1",
     "zod": "^3.24.1"

--- a/src/components/PaneView.tsx
+++ b/src/components/PaneView.tsx
@@ -1,5 +1,6 @@
-import { Component, Show } from "solid-js"
+import { Component, Show, createEffect } from "solid-js"
 import type { RunningPane, ThemeConfig } from "../types"
+import { createTerminalFeeder, type TerminalFeedSource } from "../lib/terminal-feed"
 
 export interface PaneViewProps {
   pane: RunningPane | undefined
@@ -12,6 +13,14 @@ export interface PaneViewProps {
 export const PaneView: Component<PaneViewProps> = (props) => {
   const contentWidth = () => Math.max(1, props.width - 2)
   const contentHeight = () => Math.max(1, props.height - 3)
+
+  const feeder = createTerminalFeeder()
+  const source = (): TerminalFeedSource | undefined => {
+    const pane = props.pane
+    if (!pane) return undefined
+    return { buffer: pane.buffer, seq: pane.seq, key: `${pane.paneId}:${pane.runId}` }
+  }
+  createEffect(() => feeder.sync(source()))
 
   return (
     <box
@@ -39,7 +48,7 @@ export const PaneView: Component<PaneViewProps> = (props) => {
             </box>
             <box width={contentWidth()} height={contentHeight()} overflow="hidden">
               <ghostty-terminal
-                ansi={pane().buffer}
+                ref={(el: any) => feeder.attach(el, source())}
                 cols={contentWidth()}
                 rows={contentHeight()}
                 showCursor

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,5 +1,6 @@
-import { Component, Show } from "solid-js"
+import { Component, Show, createEffect } from "solid-js"
 import type { RunningApp, ThemeConfig } from "../types"
+import { createTerminalFeeder, type TerminalFeedSource } from "../lib/terminal-feed"
 
 export interface TerminalPaneProps {
   runningApp: RunningApp | undefined
@@ -13,6 +14,15 @@ export interface TerminalPaneProps {
 export const TerminalPane: Component<TerminalPaneProps> = (props) => {
   const contentWidth = () => Math.max(1, props.width - 2)
   const contentHeight = () => Math.max(1, props.height - 3)
+
+  const feeder = createTerminalFeeder()
+  const source = (): TerminalFeedSource | undefined => {
+    const app = props.runningApp
+    if (!app) return undefined
+    return { buffer: app.buffer, seq: app.seq, key: `${app.entry.id}:${app.runId}` }
+  }
+  // Feed new output as it arrives (source() reads buffer/seq reactively).
+  createEffect(() => feeder.sync(source()))
 
   return (
     <box
@@ -44,10 +54,10 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
               </text>
             </box>
 
-            {/* Terminal content */}
+            {/* Terminal content — persistent mode, fed deltas via the feeder. */}
             <box width={contentWidth()} height={contentHeight()} overflow="hidden">
               <ghostty-terminal
-                ansi={app().buffer}
+                ref={(el: any) => feeder.attach(el, source())}
                 cols={contentWidth()}
                 rows={contentHeight()}
                 showCursor

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,9 +66,26 @@ async function main() {
       process.exit(1)
     }
     
-    // Register the ghostty-terminal component
+    // Register the ghostty-terminal component.
+    //
+    // We force persistent (stateful) mode. The OpenTUI reconciler constructs
+    // renderables with only `{ id }` and applies the rest of the props via
+    // setters afterwards — but `persistent` can only be enabled at construction
+    // time (its setter is a no-op). So we inject it here via a subclass.
+    //
+    // Persistent mode is what makes full-screen TUIs (Claude Code, btop, …)
+    // render correctly: we feed PTY deltas into a stateful grid instead of
+    // re-parsing an ever-growing, char-capped ANSI string each frame. The old
+    // stateless path sliced the raw byte stream mid-escape-sequence (producing
+    // artifacts like a literal "5m") and dropped cursor-positioning gaps (the
+    // collapsed/squished whitespace). See TerminalPane/PaneView for the feed.
     debugLog("[init] Calling extend() to register ghostty-terminal...")
-    extend({ "ghostty-terminal": GhosttyTerminalRenderable })
+    class PersistentGhosttyTerminal extends GhosttyTerminalRenderable {
+      constructor(ctx: any, options: any) {
+        super(ctx, { ...options, persistent: true })
+      }
+    }
+    extend({ "ghostty-terminal": PersistentGhosttyTerminal as any })
     debugLog("[init] extend() completed")
     
     // Load configuration

--- a/src/lib/terminal-feed.ts
+++ b/src/lib/terminal-feed.ts
@@ -1,0 +1,91 @@
+/**
+ * Drives a persistent `<ghostty-terminal>` renderable by feeding it only the
+ * *new* output since the last update, instead of re-setting the whole ANSI
+ * buffer each frame.
+ *
+ * Why this exists: the stateless path (`ansi={fullBuffer}`) re-parsed an
+ * ever-growing, char-capped string on every render. That `.slice(-cap)` cut the
+ * byte stream mid-escape-sequence (leaving literal junk like "5m") and, once the
+ * foundational paint scrolled past the cap, full-screen apps' cursor-positioning
+ * gaps collapsed into squished text. Feeding deltas into a stateful grid avoids
+ * both: the grid is the source of truth and is never sliced.
+ *
+ * The renderable must be in persistent mode (forced at construction in
+ * index.tsx). If a platform lacks native persistent support, `feed()` throws and
+ * we transparently fall back to the old stateless `ansi=` behaviour.
+ */
+export interface TerminalFeedSource {
+  /** Accumulated (char-capped) output, used to replay state on (re)attach. */
+  buffer: string
+  /** Monotonic total-bytes counter; absent until the first chunk. */
+  seq?: number
+  /** Identity of the current run. Changes on app switch or restart -> reset. */
+  key: string
+}
+
+export interface TerminalFeeder {
+  /** Feed any new output for `src` into the attached terminal. */
+  sync: (src: TerminalFeedSource | undefined) => void
+  /** Bind the renderable instance (callback ref) and replay current state. */
+  attach: (el: any, src: TerminalFeedSource | undefined) => void
+}
+
+export function createTerminalFeeder(): TerminalFeeder {
+  let term: any = null
+  let fedSeq = 0
+  let lastKey = ""
+  let persistentOk = true
+
+  const sync = (src: TerminalFeedSource | undefined): void => {
+    if (!src || !term) return
+    const buffer = src.buffer ?? ""
+
+    // Fallback path: no native persistent support -> behave like the old code.
+    if (!persistentOk) {
+      if (term.ansi !== buffer) term.ansi = buffer
+      return
+    }
+
+    // A new run (tab switch or restart) means a fresh grid + full replay.
+    if (src.key !== lastKey) {
+      try {
+        term.reset()
+      } catch {
+        // reset only exists in persistent mode; ignore if unavailable.
+      }
+      fedSeq = 0
+      lastKey = src.key
+    }
+
+    const seq = src.seq ?? buffer.length
+    const newCount = seq - fedSeq
+    if (newCount <= 0) return
+
+    // `newCount >= buffer.length` means we're replaying from scratch (or fell
+    // behind the cap) — feed the whole available buffer. Otherwise feed exactly
+    // the new tail; slicing from the end is correct even when the buffer
+    // front-trimmed, because the new bytes were just appended.
+    const chunk = newCount >= buffer.length ? buffer : buffer.slice(-newCount)
+    try {
+      term.feed(chunk)
+      fedSeq = seq
+    } catch {
+      // Native persistent support missing — degrade to stateless rendering.
+      persistentOk = false
+      try {
+        term.ansi = buffer
+      } catch {
+        // nothing more we can do
+      }
+    }
+  }
+
+  const attach = (el: any, src: TerminalFeedSource | undefined): void => {
+    term = el
+    lastKey = ""
+    fedSeq = 0
+    sync(src)
+  }
+
+  return { sync, attach }
+}

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -84,8 +84,9 @@ export function createTabsStore() {
       const app = apps.get(id)
       if (app) {
         const nextBuffer = (app.buffer + data).slice(-MAX_BUFFER_CHARS)
+        const nextSeq = (app.seq ?? app.buffer.length) + data.length
         const newApps = new Map(apps)
-        newApps.set(id, { ...app, buffer: nextBuffer })
+        newApps.set(id, { ...app, buffer: nextBuffer, seq: nextSeq })
         return newApps
       }
       return apps

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -101,7 +101,8 @@ export function createWindowsStore() {
       if (!pane) return current
       const next = new Map(current)
       const nextBuffer = (pane.buffer + data).slice(-MAX_BUFFER_CHARS)
-      next.set(paneId, { ...pane, buffer: nextBuffer })
+      const nextSeq = (pane.seq ?? pane.buffer.length) + data.length
+      next.set(paneId, { ...pane, buffer: nextBuffer, seq: nextSeq })
       return next
     })
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,13 @@ export interface RunningApp {
   status: AppStatus
   buffer: string
   runId: number
+  /**
+   * Monotonic count of total output bytes ever received for this run. Unlike
+   * `buffer.length` (which front-trims at the cap), this never decreases, so
+   * the renderer can compute exactly which tail of `buffer` is new and feed
+   * only that delta to the persistent terminal. Absent until the first chunk.
+   */
+  seq?: number
 }
 
 export interface RunningPane {
@@ -70,6 +77,8 @@ export interface RunningPane {
   status: AppStatus
   buffer: string
   runId: number
+  /** See {@link RunningApp.seq}. */
+  seq?: number
 }
 
 export interface WindowState {


### PR DESCRIPTION
## Problem

Two independent bugs garbled child-app output inside tuidoscope panes:

1. **btop** showed literal escape fragments (`5mbwrap…`) and stray colored cells. Output was stored as one ever-growing ANSI string capped with `.slice(-200_000)` and re-parsed statelessly each frame; the slice cut the byte stream mid-escape-sequence, so a `\e[5m` whose `\e[` got chopped rendered as literal `5m`.
2. **Claude Code** text was squished (`Tips for getting started` → `Tipsforgettingstarted`). Claude positions every word with absolute-column cursor moves (`Tips\e[61Gfor\e[65Ggetting…`); `ghostty-opentui` 1.3.11 dropped the unwritten cells between them when serializing the grid. Confirmed: `getText()` kept the spacing, only `getJson()` dropped it.

## Fix (two complementary parts)

- **Render via the ghostty persistent terminal**: feed PTY deltas into a stateful grid instead of re-parsing a sliced string — no mid-escape corruption (fixes btop). `index.tsx` registers a persistent-forcing subclass because OpenTUI constructs renderables with only `{ id }` and `persistent` is a construction-time option. `TerminalPane`/`PaneView` attach via `ref` and feed deltas through a shared `terminal-feed` helper; stores track a monotonic `seq` so the correct tail is fed even when the buffer front-trims.
- **Upgrade `ghostty-opentui` 1.3.11 → 1.5.0**, which emits empty cells as spaces (fixes the squish). API-compatible; `@opentui/core` peer is `*`.

Both parts are needed — 1.5.0 alone wouldn't fix btop's slicing; persistent mode alone wouldn't fix Claude's positioning.

## Validation

Verified live (isolated instance) against real **btop** and **Claude Code**: spacing intact, two-column layouts correct, escape-artifact scan clean. Typecheck + build pass.

### Caveats / follow-ups
- The persistent terminal uses unlimited scrollback, so a very long-running *non*-full-screen shell could grow memory over time.
- On tab-switch-*back* the replay feeds the capped buffer, so one frame could be briefly stale before the app repaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)