### PR TITLE
Graphite UI reskin + embedded-terminal resize & Ctrl+C fixes

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -34,9 +34,14 @@ version: 2                    # Config schema version (required)
 theme: { ... }                # Color theme
 tab_width: 20                 # Tab sidebar width
 layout: "classic"            # classic or zellij layout
+focus_on_launch: true         # Jump focus into a pane when its app launches (default: true)
 apps: [ ... ]                 # Application entries
 session: { ... }              # Session persistence
 ```
+
+When `focus_on_launch` is `true` (the default), launching an app automatically
+switches into TERMINAL mode so you can type immediately. Set it to `false` to stay
+in TABS/MANAGER focus after launching.
 
 Runtime override: `tuidoscope --layout zellij`.
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,6 +20,8 @@ import { saveConfig } from "./lib/config"
 import { matchesKeybind } from "./lib/keybinds"
 import { debugLog } from "./lib/debug"
 import { getThemeById } from "./lib/themes"
+import { resolveTheme } from "./lib/palette"
+import { widthMode } from "./lib/width-layout"
 import { computePaneRects, collectPaneIds } from "./lib/layout"
 import type { SessionClient } from "./lib/session-client"
 import type { RunningAppSnapshot, RunningPaneSnapshot, ServerMessage, WindowSnapshot } from "./lib/ipc"
@@ -54,6 +56,12 @@ export const App: Component<AppProps> = (props) => {
   const [lastGTime, setLastGTime] = createSignal(0)
   const [currentTheme, setCurrentTheme] = createSignal<ThemeConfig>(props.config.theme)
 
+  // Derive the rich graphite-style palette from the 5-token theme (memoized).
+  const palette = createMemo(() => resolveTheme(currentTheme()))
+
+  // Responsive width mode (full / compact / minimum) drives chrome + sidebar collapse.
+  const layoutWidthMode = createMemo(() => widthMode(terminalDims().width))
+
   // Double-tap Ctrl+A detection for passthrough
   let lastCtrlATime = 0
 
@@ -62,9 +70,12 @@ export const App: Component<AppProps> = (props) => {
 
   const isZellijLayout = () => layoutMode() === "zellij"
 
+  const classicSidebarWidth = () =>
+    layoutWidthMode() === "minimum" ? 0 : props.config.tab_width
+
   const getClassicPtyDimensions = () => {
     const dims = terminalDims()
-    const cols = dims.width - props.config.tab_width - 2
+    const cols = dims.width - classicSidebarWidth() - 2
     const rows = dims.height - 4
     return { cols, rows }
   }
@@ -73,6 +84,17 @@ export const App: Component<AppProps> = (props) => {
     tabsStore.setActiveTab(id)
     if (options.broadcast) {
       props.sessionClient.setActiveTab(id)
+    }
+  }
+
+  // When an app launches, optionally jump focus straight into its pane so the
+  // user can start typing immediately (configurable via focus_on_launch).
+  const focusPaneOnLaunch = () => {
+    if (!props.config.focus_on_launch) return
+    if (isZellijLayout()) {
+      windowsStore.setFocusMode("terminal")
+    } else {
+      tabsStore.setFocusMode("terminal")
     }
   }
 
@@ -93,6 +115,7 @@ export const App: Component<AppProps> = (props) => {
 
     props.sessionClient.start(entry)
     setActiveTab(entry.id, { broadcast: true })
+    focusPaneOnLaunch()
     uiStore.showTemporaryMessage(`Started: ${entry.name}`)
   }
 
@@ -174,6 +197,7 @@ export const App: Component<AppProps> = (props) => {
 
     if (isZellijLayout()) {
       props.sessionClient.createWindow(entry)
+      focusPaneOnLaunch()
       return
     }
 
@@ -980,26 +1004,28 @@ export const App: Component<AppProps> = (props) => {
         when={isZellijLayout()}
         fallback={
           <box flexDirection="row" flexGrow={1}>
-            <TabList
-              entries={appsStore.store.entries}
-              activeTabId={tabsStore.store.activeTabId}
-              selectedIndex={selectedIndex()}
-              getStatus={getAppStatus}
-              isFocused={tabsStore.store.focusMode === "tabs"}
-              width={props.config.tab_width}
-              height={terminalDims().height - 1}
-              scrollOffset={tabsStore.store.scrollOffset}
-              theme={currentTheme()}
-              onSelect={handleSelectApp}
-              onAddClick={() => uiStore.openModal("add-tab")}
-            />
+            <Show when={layoutWidthMode() !== "minimum"}>
+              <TabList
+                entries={appsStore.store.entries}
+                activeTabId={tabsStore.store.activeTabId}
+                selectedIndex={selectedIndex()}
+                getStatus={getAppStatus}
+                isFocused={tabsStore.store.focusMode === "tabs"}
+                width={props.config.tab_width}
+                height={terminalDims().height - 1}
+                scrollOffset={tabsStore.store.scrollOffset}
+                theme={palette()}
+                onSelect={handleSelectApp}
+                onAddClick={() => uiStore.openModal("add-tab")}
+              />
+            </Show>
 
             <TerminalPane
               runningApp={activeRunningApp()}
               isFocused={tabsStore.store.focusMode === "terminal"}
-              width={terminalDims().width - props.config.tab_width}
+              width={terminalDims().width - classicSidebarWidth()}
               height={terminalDims().height - 1}
-              theme={currentTheme()}
+              theme={palette()}
               onInput={handleTerminalInput}
             />
           </box>
@@ -1012,12 +1038,12 @@ export const App: Component<AppProps> = (props) => {
             activePaneId={windowsStore.store.activePaneId}
             width={terminalDims().width}
             height={terminalDims().height - 2}
-            theme={currentTheme()}
+            theme={palette()}
           />
           <WindowBar
             windows={windowsStore.store.windows}
             activeWindowId={windowsStore.store.activeWindowId}
-            theme={currentTheme()}
+            theme={palette()}
             onSelect={activateWindow}
           />
         </box>
@@ -1033,15 +1059,17 @@ export const App: Component<AppProps> = (props) => {
         appStatus={isZellijLayout() ? activeRunningPane()?.status ?? null : activeRunningApp()?.status ?? null}
         focusMode={isZellijLayout() ? windowsStore.store.focusMode : tabsStore.store.focusMode}
         message={uiStore.store.statusMessage}
-        theme={currentTheme()}
+        theme={palette()}
         layoutMode={layoutMode()}
+        widthMode={layoutWidthMode()}
+        termWidth={terminalDims().width}
       />
 
       {/* Modals */}
       <Show when={uiStore.store.activeModal === "command-palette"}>
         <CommandPalette
           entries={appsStore.store.entries}
-          theme={currentTheme()}
+          theme={palette()}
           onSelect={(entry, action) => {
             if (action === "edit") {
               openEditModal(entry.id)
@@ -1057,6 +1085,7 @@ export const App: Component<AppProps> = (props) => {
             if (isZellijLayout()) {
               if (action === "switch") {
                 props.sessionClient.createWindow(entry)
+                focusPaneOnLaunch()
                 return
               }
               if (action === "stop") {
@@ -1092,7 +1121,7 @@ export const App: Component<AppProps> = (props) => {
 
       <Show when={uiStore.store.activeModal === "add-tab"}>
         <AddTabModal
-          theme={currentTheme()}
+          theme={palette()}
           onAdd={handleAddApp}
           onClose={() => uiStore.closeModal()}
         />
@@ -1100,7 +1129,7 @@ export const App: Component<AppProps> = (props) => {
 
       <Show when={uiStore.store.activeModal === "edit-app" && editingEntry()}>
         <EditAppModal
-          theme={currentTheme()}
+          theme={palette()}
           entry={editingEntry()!}
           onSave={(updates) => handleEditApp(editingEntry()!.id, updates)}
           onDelete={() => {
@@ -1117,7 +1146,7 @@ export const App: Component<AppProps> = (props) => {
 
       <Show when={uiStore.store.activeModal === "confirm-delete" && deletingEntry()}>
         <ConfirmDialog
-          theme={currentTheme()}
+          theme={palette()}
           title="Delete app?"
           message={`Delete "${deletingEntry()!.name}" from your app list?`}
           detail="This removes it from your config. (it can be re-added later)"
@@ -1130,7 +1159,7 @@ export const App: Component<AppProps> = (props) => {
 
       <Show when={uiStore.store.activeModal === "help"}>
         <HelpModal
-          theme={currentTheme()}
+          theme={palette()}
           layoutMode={layoutMode()}
           onClose={() => uiStore.closeModal()}
         />
@@ -1138,7 +1167,7 @@ export const App: Component<AppProps> = (props) => {
 
       <Show when={uiStore.store.activeModal === "theme-picker"}>
         <ThemePicker
-          theme={currentTheme()}
+          theme={palette()}
           onSelect={(themeId) => {
             void handleThemeChange(themeId)
           }}

--- a/src/components/AddTabModal.tsx
+++ b/src/components/AddTabModal.tsx
@@ -1,12 +1,13 @@
 import { Component, createSignal, createMemo, createEffect, onCleanup } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { ThemeConfig, AppEntryConfig } from "../types"
+import type { AppEntryConfig } from "../types"
+import type { Palette } from "../lib/palette"
 import { APP_PRESETS, type AppPreset } from "../lib/presets"
 import { commandExists } from "../lib/command"
 import { DialogBox } from "./DialogBox"
 
 export interface AddTabModalProps {
-  theme: ThemeConfig
+  theme: Palette
   onAdd: (entry: AppEntryConfig) => void
   onClose: () => void
 }
@@ -179,59 +180,59 @@ export const AddTabModal: Component<AddTabModalProps> = (props) => {
   })
 
   return (
-    <DialogBox
-      theme={props.theme}
-      top="20%"
-      left="20%"
-      width="60%"
-      height={20}
-    >
+    <DialogBox theme={props.theme} width="60%" height={20}>
       {/* Title */}
-      <box height={1}>
+      <box height={1} paddingLeft={2}>
         <text fg={props.theme.accent}>
-          <b> Add New App</b>
+          <b>Add New App</b>
         </text>
       </box>
 
       {/* Mode tabs */}
-      <box height={1} flexDirection="row">
+      <box height={1} flexDirection="row" paddingLeft={2}>
         <text
-          fg={mode() === "preset" ? props.theme.background : props.theme.muted}
-          bg={mode() === "preset" ? props.theme.primary : undefined}
+          fg={mode() === "preset" ? props.theme.accent : props.theme.textDim}
+          bg={mode() === "preset" ? props.theme.surfaceAlt : undefined}
         >
-          {" [Presets] "}
+          {" Presets "}
         </text>
+        <text> </text>
         <text
-          fg={mode() === "custom" ? props.theme.background : props.theme.muted}
-          bg={mode() === "custom" ? props.theme.primary : undefined}
+          fg={mode() === "custom" ? props.theme.accent : props.theme.textDim}
+          bg={mode() === "custom" ? props.theme.surfaceAlt : undefined}
         >
-          {" [Custom] "}
+          {" Custom "}
         </text>
       </box>
 
+      <box height={1} />
+
       {/* Preset list - show when mode is preset */}
       {mode() === "preset" && (
-        <box flexDirection="column" flexGrow={1}>
+        <box flexDirection="column" flexGrow={1} paddingRight={2}>
           {presetsWithAvailability()
             .slice(scrollOffset(), scrollOffset() + VISIBLE_PRESETS)
             .map((preset, index) => {
               const actualIndex = () => scrollOffset() + index
               const isSelected = () => selectedPresetIndex() === actualIndex()
+              const unavailable = () => preset.available === false
+              const dot = () =>
+                preset.available === true ? "●" : preset.available === false ? "·" : "?"
+              const dotColor = () =>
+                preset.available === true
+                  ? props.theme.on
+                  : preset.available === false
+                    ? props.theme.off
+                    : props.theme.warn
               return (
-                <box height={1} flexDirection="row">
-                  <text
-                    fg={
-                      preset.available === false
-                        ? props.theme.muted
-                        : isSelected()
-                          ? props.theme.background
-                          : props.theme.foreground
-                    }
-                    bg={isSelected() ? props.theme.primary : undefined}
-                  >
-                    {preset.available === true ? " [*] " : preset.available === false ? " [ ] " : " [?] "}
+                <box height={1} flexDirection="row" backgroundColor={isSelected() ? props.theme.surfaceAlt : undefined}>
+                  <box width={1} height={1} backgroundColor={isSelected() ? props.theme.accent : undefined} />
+                  <text fg={dotColor()}>{" " + dot() + " "}</text>
+                  <text fg={unavailable() ? props.theme.textDim : (isSelected() ? props.theme.text : props.theme.textDim)}>
                     {preset.name.padEnd(18)}
-                    {preset.command.padEnd(20)}
+                  </text>
+                  <text fg={props.theme.textDim}>
+                    {preset.command.padEnd(18)}
                     {preset.description}
                   </text>
                 </box>
@@ -239,8 +240,8 @@ export const AddTabModal: Component<AddTabModalProps> = (props) => {
             })}
           {/* Scroll indicator */}
           {presetsWithAvailability().length > VISIBLE_PRESETS && (
-            <box height={1}>
-              <text fg={props.theme.muted}>
+            <box height={1} paddingLeft={2}>
+              <text fg={props.theme.textDim}>
                 {scrollOffset() > 0 ? "↑ " : "  "}
                 {selectedPresetIndex() + 1}/{presetsWithAvailability().length}
                 {scrollOffset() + VISIBLE_PRESETS < presetsWithAvailability().length ? " ↓" : ""}
@@ -252,17 +253,17 @@ export const AddTabModal: Component<AddTabModalProps> = (props) => {
 
       {/* Custom form fields - show when mode is custom */}
       {mode() === "custom" && (
-        <box flexDirection="column" flexGrow={1}>
+        <box flexDirection="column" flexGrow={1} paddingLeft={2} paddingRight={2}>
           {fields.map((field) => {
             const isFocused = () => focusedField() === field.key
             return (
               <box height={1} flexDirection="row">
                 <box width={12}>
-                  <text fg={isFocused() ? props.theme.accent : props.theme.muted}>{field.label}:</text>
+                  <text fg={isFocused() ? props.theme.accent : props.theme.textDim}>{field.label}:</text>
                 </box>
                 <text
-                  fg={isFocused() ? props.theme.foreground : props.theme.muted}
-                  bg={isFocused() ? props.theme.primary : undefined}
+                  fg={props.theme.text}
+                  bg={isFocused() ? props.theme.surfaceAlt : undefined}
                 >
                   {" "}{field.value()}{isFocused() ? "█" : " "}
                 </text>
@@ -273,13 +274,33 @@ export const AddTabModal: Component<AddTabModalProps> = (props) => {
       )}
 
       {/* Footer - different hints based on mode */}
-      <box height={1}>
-        <text fg={props.theme.muted}>
-          {mode() === "preset"
-            ? "Enter:Select | Tab:Custom | Esc:Cancel | j/k:Navigate"
-            : "Enter:Add | Tab:Presets | Esc:Cancel | ↑/↓:Field"}
-        </text>
+      <box height={1} flexDirection="row" paddingLeft={2}>
+        {mode() === "preset" ? (
+          <>
+            <Hint theme={props.theme} keyLabel="↵" desc="add" />
+            <Hint theme={props.theme} keyLabel="tab" desc="custom" />
+            <Hint theme={props.theme} keyLabel="j/k" desc="nav" />
+            <Hint theme={props.theme} keyLabel="esc" desc="cancel" />
+          </>
+        ) : (
+          <>
+            <Hint theme={props.theme} keyLabel="↵" desc="add" />
+            <Hint theme={props.theme} keyLabel="tab" desc="presets" />
+            <Hint theme={props.theme} keyLabel="↑↓" desc="field" />
+            <Hint theme={props.theme} keyLabel="esc" desc="cancel" />
+          </>
+        )}
       </box>
     </DialogBox>
   )
 }
+
+const Hint: Component<{ theme: Palette; keyLabel: string; desc: string }> = (props) => (
+  <>
+    <text fg={props.theme.accent}>
+      {"  "}
+      <b>{props.keyLabel}</b>
+    </text>
+    <text fg={props.theme.textDim}>{" " + props.desc}</text>
+  </>
+)

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import { Component, For, createSignal, createMemo, createEffect } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { AppEntry, ThemeConfig } from "../types"
+import type { AppEntry } from "../types"
+import type { Palette } from "../lib/palette"
 import { createAppSearch } from "../lib/fuzzy"
 import { buildEntryCommand } from "../lib/command"
 import { getVisibleWindowOffset } from "../lib/list-window"
@@ -11,7 +12,7 @@ export type GlobalAction = { type: "open_theme_picker" }
 
 export interface CommandPaletteProps {
   entries: AppEntry[]
-  theme: ThemeConfig
+  theme: Palette
   onSelect: (entry: AppEntry, action: CommandAction) => void
   onGlobalAction?: (action: GlobalAction) => void
   onClose: () => void
@@ -158,75 +159,63 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
   })
 
   return (
-    <DialogBox
-      theme={props.theme}
-      top="20%"
-      left="20%"
-      width="60%"
-      height="60%"
-    >
+    <DialogBox theme={props.theme} width="60%" height="60%">
       {/* Search input */}
-      <box
-        height={3}
-        flexDirection="row"
-        borderStyle="single"
-        borderColor={props.theme.muted}
-        paddingLeft={1}
-        paddingRight={1}
-      >
-        <box height={1} flexDirection="row" flexGrow={1}>
-          <text fg={props.theme.muted}>{"> "}</text>
-          <input
-            height={1}
-            flexGrow={1}
-            value={query()}
-            focused
-            backgroundColor={props.theme.background}
-            textColor={props.theme.foreground}
-            focusedBackgroundColor={props.theme.background}
-            focusedTextColor={props.theme.foreground}
-            placeholder="Search apps or commands..."
-            placeholderColor={props.theme.muted}
-            cursorColor={props.theme.accent}
-            onInput={(value) => setQuery(value)}
-            onSubmit={() => {
-              const selected = results()[selectedIndex()]
-              if (selected) {
-                handleSelect(selected, "switch")
-              }
-            }}
-          />
-        </box>
+      <box height={1} flexDirection="row" paddingLeft={2} paddingRight={2}>
+        <text fg={props.theme.textDim}>{"› "}</text>
+        <input
+          height={1}
+          flexGrow={1}
+          value={query()}
+          focused
+          backgroundColor={props.theme.surface}
+          textColor={props.theme.text}
+          focusedBackgroundColor={props.theme.surface}
+          focusedTextColor={props.theme.text}
+          placeholder="Search apps or commands..."
+          placeholderColor={props.theme.textDim}
+          cursorColor={props.theme.accent}
+          onInput={(value) => setQuery(value)}
+          onSubmit={() => {
+            const selected = results()[selectedIndex()]
+            if (selected) {
+              handleSelect(selected, "switch")
+            }
+          }}
+        />
       </box>
 
+      <box height={1} />
+
       {/* Results list */}
-      <box flexDirection="column" flexGrow={1} overflow="hidden">
+      <box flexDirection="column" flexGrow={1} overflow="hidden" paddingRight={2}>
         <For each={visibleResults()}>
           {(result, index) => {
             const actualIndex = () => visibleOffset() + index()
             const isSelected = () => actualIndex() === selectedIndex()
             const displayText = () => {
               if (result.type === "command") {
-                return `[Cmd] ${result.command.name}`
+                return result.command.name
               }
-              return `${result.item.name} - ${buildEntryCommand(result.item)}`
+              return `${result.item.name} — ${buildEntryCommand(result.item)}`
             }
             const isCommand = () => result.type === "command"
-            
+
             return (
               <box
                 height={1}
                 width="100%"
                 flexDirection="row"
-                backgroundColor={isSelected() ? props.theme.primary : props.theme.background}
+                backgroundColor={isSelected() ? props.theme.surfaceAlt : undefined}
                 onMouseDown={() => handleSelect(result, "switch")}
               >
+                {/* accent rail */}
+                <box width={1} height={1} backgroundColor={isSelected() ? props.theme.accent : undefined} />
                 <text
                   width="100%"
-                  fg={isSelected() ? props.theme.background : (isCommand() ? props.theme.accent : props.theme.foreground)}
-                  bg={isSelected() ? props.theme.primary : props.theme.background}
+                  fg={isCommand() ? props.theme.accent : (isSelected() ? props.theme.text : props.theme.textDim)}
                 >
-                  {" "}{displayText()}
+                  {(isCommand() ? " ⌘ " : " ")}{displayText()}
                 </text>
               </box>
             )
@@ -235,19 +224,23 @@ export const CommandPalette: Component<CommandPaletteProps> = (props) => {
       </box>
 
       {/* Footer hints */}
-      <box
-        height={3}
-        borderStyle="single"
-        borderColor={props.theme.muted}
-        paddingLeft={1}
-        paddingRight={1}
-      >
-        <box height={1}>
-          <text fg={props.theme.muted}>
-            Enter:Select | x:Stop | Ctrl+E:Edit | Ctrl+R:Delete | Esc:Close | ↑↓:Navigate
-          </text>
-        </box>
+      <box height={1} flexDirection="row" paddingLeft={2} paddingRight={2}>
+        <Hint theme={props.theme} keyLabel="↵" desc="select" />
+        <Hint theme={props.theme} keyLabel="x" desc="stop" />
+        <Hint theme={props.theme} keyLabel="^E" desc="edit" />
+        <Hint theme={props.theme} keyLabel="^R" desc="delete" />
+        <Hint theme={props.theme} keyLabel="esc" desc="close" />
       </box>
     </DialogBox>
   )
 }
+
+const Hint: Component<{ theme: Palette; keyLabel: string; desc: string }> = (props) => (
+  <>
+    <text fg={props.theme.accent}>
+      {"  "}
+      <b>{props.keyLabel}</b>
+    </text>
+    <text fg={props.theme.textDim}>{" " + props.desc}</text>
+  </>
+)

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,10 +1,10 @@
 import { Component } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { ThemeConfig } from "../types"
+import type { Palette } from "../lib/palette"
 import { DialogBox } from "./DialogBox"
 
 export interface ConfirmDialogProps {
-  theme: ThemeConfig
+  theme: Palette
   title: string
   message: string
   detail?: string
@@ -31,10 +31,10 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
   })
 
   return (
-    <DialogBox theme={props.theme} top="35%" left="25%" width="50%" height={9}>
+    <DialogBox theme={props.theme} width="50%" height={9}>
       {/* Title */}
-      <box height={1} paddingLeft={1}>
-        <text fg={props.theme.accent}>
+      <box height={1} paddingLeft={2}>
+        <text fg={props.theme.error}>
           <b>{props.title}</b>
         </text>
       </box>
@@ -42,24 +42,24 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
       <box height={1} />
 
       {/* Message */}
-      <box height={1} paddingLeft={1} paddingRight={1}>
-        <text fg={props.theme.foreground}>{props.message}</text>
+      <box height={1} paddingLeft={2} paddingRight={2}>
+        <text fg={props.theme.text}>{props.message}</text>
       </box>
 
       {/* Optional detail line */}
       {props.detail ? (
-        <box height={1} paddingLeft={1} paddingRight={1}>
-          <text fg={props.theme.muted}>{props.detail}</text>
+        <box height={1} paddingLeft={2} paddingRight={2}>
+          <text fg={props.theme.textDim}>{props.detail}</text>
         </box>
       ) : null}
 
       <box flexGrow={1} />
 
       {/* Footer */}
-      <box height={1} paddingLeft={1}>
-        <text fg={props.theme.muted}>
+      <box height={1} paddingLeft={2}>
+        <text fg={props.theme.textDim}>
           {props.confirmHint ?? "y:Confirm"}
-          {"  |  "}
+          {"   "}
           {props.cancelHint ?? "n/Esc:Cancel"}
         </text>
       </box>

--- a/src/components/DialogBox.tsx
+++ b/src/components/DialogBox.tsx
@@ -1,30 +1,50 @@
 import { Component } from "solid-js"
 import type { JSX } from "solid-js"
-import type { ThemeConfig } from "../types"
+import { useTerminalDimensions } from "@opentui/solid"
+import type { Palette } from "../lib/palette"
 
-type DimensionValue = number | "auto" | `${number}%`
+type DimensionValue = number | `${number}%`
 
 export interface DialogBoxProps {
-  theme: ThemeConfig
-  top?: DimensionValue
-  left?: DimensionValue
+  theme: Palette
+  /** Desired width — a column count or a `%` of the terminal. Default 60%. */
   width?: DimensionValue
+  /** Desired height — a row count or a `%` of the terminal. Default 50%. */
   height?: DimensionValue
   children?: JSX.Element
 }
 
+function resolveDim(value: DimensionValue | undefined, total: number, fallbackPct: number): number {
+  if (typeof value === "number") return value
+  if (typeof value === "string" && value.endsWith("%")) {
+    return Math.round((parseFloat(value) / 100) * total)
+  }
+  return Math.round((fallbackPct / 100) * total)
+}
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+
 export const DialogBox: Component<DialogBoxProps> = (props) => {
+  const dims = useTerminalDimensions()
+
+  const w = () => clamp(resolveDim(props.width, dims().width, 60), 24, Math.max(24, dims().width - 2))
+  const h = () => clamp(resolveDim(props.height, dims().height, 50), 5, Math.max(5, dims().height - 2))
+  const left = () => Math.max(0, Math.floor((dims().width - w()) / 2))
+  const top = () => Math.max(0, Math.floor((dims().height - h()) / 2))
+
   return (
     <box
       position="absolute"
-      top={props.top ?? "20%"}
-      left={props.left ?? "20%"}
-      width={props.width ?? "60%"}
-      height={props.height ?? 10}
+      top={top()}
+      left={left()}
+      width={w()}
+      height={h()}
       flexDirection="column"
-      borderStyle="double"
-      borderColor={props.theme.primary}
-      backgroundColor={props.theme.background}
+      paddingTop={1}
+      paddingBottom={1}
+      borderStyle="rounded"
+      borderColor={props.theme.borderFocus}
+      backgroundColor={props.theme.surface}
     >
       {props.children}
     </box>

--- a/src/components/EditAppModal.tsx
+++ b/src/components/EditAppModal.tsx
@@ -1,10 +1,11 @@
 import { Component, createSignal } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { ThemeConfig, AppEntry } from "../types"
+import type { AppEntry } from "../types"
+import type { Palette } from "../lib/palette"
 import { DialogBox } from "./DialogBox"
 
 export interface EditAppModalProps {
-  theme: ThemeConfig
+  theme: Palette
   entry: Pick<AppEntry, "id" | "name" | "command" | "args" | "cwd">
   onSave: (updates: { name: string; command: string; args?: string; cwd: string }) => void
   onDelete: () => void
@@ -90,44 +91,53 @@ export const EditAppModal: Component<EditAppModalProps> = (props) => {
   })
 
   return (
-    <DialogBox
-      theme={props.theme}
-      top="30%"
-      left="25%"
-      width="50%"
-      height={12}
-    >
+    <DialogBox theme={props.theme} width="50%" height={12}>
       {/* Title */}
-      <box height={1}>
+      <box height={1} paddingLeft={2}>
         <text fg={props.theme.accent}>
-          <b> Edit App</b>
+          <b>Edit App</b>
         </text>
       </box>
 
+      <box height={1} />
+
       {/* Fields */}
-      {fields.map((field) => {
-        const isFocused = () => focusedField() === field.key
-        return (
-          <box height={1} flexDirection="row">
-            <box width={12}>
-              <text fg={isFocused() ? props.theme.accent : props.theme.muted}>{field.label}:</text>
+      <box flexDirection="column" flexGrow={1} paddingLeft={2} paddingRight={2}>
+        {fields.map((field) => {
+          const isFocused = () => focusedField() === field.key
+          return (
+            <box height={1} flexDirection="row">
+              <box width={12}>
+                <text fg={isFocused() ? props.theme.accent : props.theme.textDim}>{field.label}:</text>
+              </box>
+              <text
+                fg={props.theme.text}
+                bg={isFocused() ? props.theme.surfaceAlt : undefined}
+              >
+                {" "}{field.value()}{isFocused() ? "█" : " "}
+              </text>
             </box>
-            <text
-              fg={isFocused() ? props.theme.foreground : props.theme.muted}
-              bg={isFocused() ? props.theme.primary : undefined}
-            >
-              {" "}{field.value()}{isFocused() ? "█" : " "}
-            </text>
-          </box>
-        )
-      })}
+          )
+        })}
+      </box>
 
       {/* Footer */}
-      <box height={1}>
-        <text fg={props.theme.muted}>
-          Enter:Save | Ctrl+D:Delete | Esc:Cancel | Tab:Next field
-        </text>
+      <box height={1} flexDirection="row" paddingLeft={2}>
+        <Hint theme={props.theme} keyLabel="↵" desc="save" />
+        <Hint theme={props.theme} keyLabel="^D" desc="delete" />
+        <Hint theme={props.theme} keyLabel="tab" desc="next" />
+        <Hint theme={props.theme} keyLabel="esc" desc="cancel" />
       </box>
     </DialogBox>
   )
 }
+
+const Hint: Component<{ theme: Palette; keyLabel: string; desc: string }> = (props) => (
+  <>
+    <text fg={props.theme.accent}>
+      {"  "}
+      <b>{props.keyLabel}</b>
+    </text>
+    <text fg={props.theme.textDim}>{" " + props.desc}</text>
+  </>
+)

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,10 +1,11 @@
 import { Component, For } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { LayoutMode, ThemeConfig } from "../types"
+import type { LayoutMode } from "../types"
+import type { Palette } from "../lib/palette"
 import { DialogBox } from "./DialogBox"
 
 export interface HelpModalProps {
-  theme: ThemeConfig
+  theme: Palette
   layoutMode?: LayoutMode
   onClose: () => void
 }
@@ -106,58 +107,68 @@ export const HelpModal: Component<HelpModalProps> = (props) => {
     }
   })
 
-  const primaryGroups = () =>
-    props.layoutMode === "zellij" ? ZELLIJ_GROUPS : TABS_GROUPS
+  const allGroups = () => [
+    ...(props.layoutMode === "zellij" ? ZELLIJ_GROUPS : TABS_GROUPS),
+    ...MODAL_GROUPS,
+  ]
   const modeLabel = () =>
     props.layoutMode === "zellij" ? "Manager" : "Tabs"
 
+  // Split groups across two balanced columns.
+  const leftColumn = () => allGroups().filter((_, i) => i % 2 === 0)
+  const rightColumn = () => allGroups().filter((_, i) => i % 2 === 1)
+
   return (
-    <DialogBox theme={props.theme} top="8%" left="18%" width="64%" height="84%">
+    <DialogBox theme={props.theme} width="80%" height="80%">
       {/* Title */}
-      <box height={1} paddingLeft={1} flexDirection="row">
+      <box height={1} paddingLeft={2} flexDirection="row">
         <text fg={props.theme.accent}>
           <b>Keyboard Shortcuts</b>
         </text>
-        <text fg={props.theme.muted}>{`   (${modeLabel()} mode)`}</text>
+        <text fg={props.theme.textDim}>{`   (${modeLabel()} mode)`}</text>
       </box>
 
       <box height={1} />
 
-      {/* Mode-specific groups */}
-      <For each={primaryGroups()}>
-        {(group) => <ShortcutGroup group={group} theme={props.theme} />}
-      </For>
-
-      {/* Shortcuts that live inside modals */}
-      <For each={MODAL_GROUPS}>
-        {(group) => <ShortcutGroup group={group} theme={props.theme} />}
-      </For>
-
-      <box flexGrow={1} />
+      {/* Two-column shortcut grid */}
+      <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={2}>
+        <box flexDirection="column" flexGrow={1} marginRight={2}>
+          <For each={leftColumn()}>
+            {(group) => <ShortcutGroup group={group} theme={props.theme} />}
+          </For>
+        </box>
+        <box flexDirection="column" flexGrow={1}>
+          <For each={rightColumn()}>
+            {(group) => <ShortcutGroup group={group} theme={props.theme} />}
+          </For>
+        </box>
+      </box>
 
       {/* Footer */}
-      <box height={1} paddingLeft={1}>
-        <text fg={props.theme.muted}>?, q or Esc to close</text>
+      <box height={1} paddingLeft={2}>
+        <text fg={props.theme.textDim}>? · q · Esc to close</text>
       </box>
     </DialogBox>
   )
 }
 
-const ShortcutGroup: Component<{ group: Group; theme: ThemeConfig }> = (props) => {
+const ShortcutGroup: Component<{ group: Group; theme: Palette }> = (props) => {
   return (
     <box flexDirection="column">
-      <box height={1} paddingLeft={1}>
-        <text fg={props.theme.primary}>
+      <box height={1}>
+        <text fg={props.theme.accent}>
           <b>{props.group.title}</b>
         </text>
       </box>
       <For each={props.group.shortcuts}>
         {(shortcut) => (
-          <box height={1} flexDirection="row" paddingLeft={2}>
-            <box width={16}>
-              <text fg={props.theme.accent}>{shortcut.keys}</text>
+          <box height={1} flexDirection="row" paddingLeft={1}>
+            <box width={14}>
+              <text fg={props.theme.accent}>
+                <b>{shortcut.keys}</b>
+              </text>
             </box>
-            <text fg={props.theme.foreground}>{shortcut.label}</text>
+            <text fg={props.theme.text}>{shortcut.label}</text>
           </box>
         )}
       </For>

--- a/src/components/PaneLayout.tsx
+++ b/src/components/PaneLayout.tsx
@@ -1,6 +1,7 @@
 import { Component } from "solid-js"
 import type { JSX } from "solid-js"
-import type { PaneLayoutNode, RunningPane, ThemeConfig } from "../types"
+import type { PaneLayoutNode, RunningPane } from "../types"
+import type { Palette } from "../lib/palette"
 import { PaneView } from "./PaneView"
 
 export interface PaneLayoutProps {
@@ -9,7 +10,7 @@ export interface PaneLayoutProps {
   activePaneId: string | null
   width: number
   height: number
-  theme: ThemeConfig
+  theme: Palette
 }
 
 function splitSize(total: number): [number, number] {
@@ -70,7 +71,7 @@ export const PaneLayout: Component<PaneLayoutProps> = (props) => {
         renderNode(props.layout, props.width, props.height)
       ) : (
         <box flexGrow={1} justifyContent="center" alignItems="center">
-          <text fg={props.theme.muted}>No panes running</text>
+          <text fg={props.theme.textDim}>No panes running</text>
         </box>
       )}
     </box>

--- a/src/components/PaneView.tsx
+++ b/src/components/PaneView.tsx
@@ -1,5 +1,6 @@
 import { Component, Show, createEffect } from "solid-js"
-import type { RunningPane, ThemeConfig } from "../types"
+import type { RunningPane } from "../types"
+import type { Palette } from "../lib/palette"
 import { createTerminalFeeder, type TerminalFeedSource } from "../lib/terminal-feed"
 
 export interface PaneViewProps {
@@ -7,7 +8,7 @@ export interface PaneViewProps {
   isActive: boolean
   width: number
   height: number
-  theme: ThemeConfig
+  theme: Palette
 }
 
 export const PaneView: Component<PaneViewProps> = (props) => {
@@ -28,23 +29,23 @@ export const PaneView: Component<PaneViewProps> = (props) => {
       width={props.width}
       height={props.height}
       borderStyle="single"
-      borderColor={props.isActive ? props.theme.primary : props.theme.muted}
+      borderColor={props.isActive ? props.theme.borderFocus : props.theme.border}
     >
       <Show
         when={props.pane}
         fallback={
           <box flexGrow={1} justifyContent="center" alignItems="center">
-            <text fg={props.theme.muted}>Empty pane</text>
+            <text fg={props.theme.textDim}>Empty pane</text>
           </box>
         }
       >
         {(pane) => (
           <box flexDirection="column" flexGrow={1}>
-            <box height={1} flexDirection="row">
+            <box height={1} flexDirection="row" backgroundColor={props.theme.surface}>
               <text fg={props.theme.accent}>
                 <b>{pane().entry.name}</b>
               </text>
-              <text fg={props.theme.muted}>{" "}({pane().status})</text>
+              <text fg={props.theme.textDim}>{" "}({pane().status})</text>
             </box>
             <box width={contentWidth()} height={contentHeight()} overflow="hidden">
               <ghostty-terminal

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,57 +1,103 @@
-import { Component, Show } from "solid-js"
-import type { FocusMode, LayoutMode, ThemeConfig } from "../types"
+import { Component, For, Show } from "solid-js"
+import type { FocusMode, LayoutMode } from "../types"
+import type { Palette } from "../lib/palette"
+import { fitHints, type Hint, type WidthMode } from "../lib/width-layout"
 
 export interface StatusBarProps {
   appName: string | null
   appStatus: string | null
   focusMode: FocusMode
   message: string | null
-  theme: ThemeConfig
+  theme: Palette
   layoutMode?: LayoutMode
+  widthMode?: WidthMode
+  termWidth?: number
 }
 
+// Hint tiers, ordered widest-first. fitHints() picks the largest set that fits.
+const CLASSIC_TABS: Hint[][] = [
+  [
+    { key: "j/k", label: "nav" },
+    { key: "↵", label: "open" },
+    { key: "space", label: "palette" },
+    { key: "t", label: "new" },
+    { key: "e", label: "edit" },
+    { key: "^A", label: "term" },
+    { key: "?", label: "help" },
+  ],
+  [
+    { key: "j/k", label: "nav" },
+    { key: "↵", label: "open" },
+    { key: "space", label: "cmd" },
+    { key: "?", label: "help" },
+  ],
+  [
+    { key: "space", label: "cmd" },
+    { key: "?", label: "help" },
+  ],
+]
+
+const ZELLIJ_MANAGER: Hint[][] = [
+  [
+    { key: "space", label: "palette" },
+    { key: "n", label: "win" },
+    { key: "v/s", label: "split" },
+    { key: "p", label: "pane" },
+    { key: "^A", label: "term" },
+    { key: "?", label: "help" },
+  ],
+  [
+    { key: "space", label: "cmd" },
+    { key: "v/s", label: "split" },
+    { key: "?", label: "help" },
+  ],
+  [{ key: "?", label: "help" }],
+]
+
 export const StatusBar: Component<StatusBarProps> = (props) => {
+  const isZellij = () => props.layoutMode === "zellij"
+
+  const hints = (): Hint[] => {
+    if (props.focusMode === "terminal") {
+      return [{ key: "^A", label: isZellij() ? "manager" : "tabs" }]
+    }
+    const tiers = isZellij() ? ZELLIJ_MANAGER : CLASSIC_TABS
+    return fitHints(props.termWidth ?? 100, tiers)
+  }
+
+  const modeTag = () =>
+    props.focusMode === "terminal" ? "TERMINAL" : isZellij() ? "MANAGER" : "TABS"
+
   return (
-    <box
-      height={1}
-      flexDirection="row"
-      backgroundColor={props.theme.muted}
-    >
-      {/* Left: keybind hints based on focus mode */}
-      <box flexGrow={1}>
-        <Show
-          when={props.focusMode === "tabs"}
-          fallback={
-            <text fg={props.theme.foreground}>
-              {props.layoutMode === "zellij" ? " Ctrl+A:Switch to Manager" : " Ctrl+A:Switch to Tabs"}
-            </text>
-          }
-        >
-          <Show
-            when={props.layoutMode === "zellij"}
-            fallback={
-              <text fg={props.theme.foreground}>
-                {" j/k:Nav  Enter:Select  Space:Palette  t:New  e:Edit  Ctrl+A:Terminal  ?:Help"}
+    <box height={1} flexDirection="row" backgroundColor={props.theme.surfaceAlt} paddingLeft={1} paddingRight={1}>
+      {/* Left: self-fitting keybind hints (key bright/bold, label dim) */}
+      <box flexDirection="row" flexGrow={1}>
+        <For each={hints()}>
+          {(hint, index) => (
+            <>
+              <text fg={props.theme.accent}>
+                {index() > 0 ? "  " : ""}
+                <b>{hint.key}</b>
               </text>
-            }
-          >
-            <text fg={props.theme.foreground}>
-              {" Space:Palette  n:NewWin  v/s:Split  p:NextPane  Ctrl+A:Terminal  ?:Help"}
-            </text>
-          </Show>
-        </Show>
+              <text fg={props.theme.textDim}>{" " + hint.label}</text>
+            </>
+          )}
+        </For>
       </box>
 
-      {/* Center: message or app info */}
-      <box>
-        <Show when={props.message} fallback={
-          <Show when={props.appName}>
-            <text fg={props.theme.accent}>
-              {props.appName}
-              {props.appStatus ? ` (${props.appStatus})` : ""}
-            </text>
-          </Show>
-        }>
+      {/* Center: transient message or active app info */}
+      <box flexDirection="row">
+        <Show
+          when={props.message}
+          fallback={
+            <Show when={props.appName}>
+              <text fg={props.theme.accent}>{props.appName}</text>
+              <text fg={props.theme.textDim}>
+                {props.appStatus ? ` (${props.appStatus})` : ""}
+              </text>
+            </Show>
+          }
+        >
           <text fg={props.theme.accent}>
             <b>{props.message}</b>
           </text>
@@ -60,13 +106,8 @@ export const StatusBar: Component<StatusBarProps> = (props) => {
 
       {/* Right: focus mode indicator */}
       <box>
-        <text fg={props.theme.foreground}>
-          {props.focusMode === "terminal"
-            ? "[TERMINAL]"
-            : props.layoutMode === "zellij"
-              ? "[MANAGER]"
-              : "[TABS]"}
-          {" "}
+        <text fg={props.focusMode === "terminal" ? props.theme.accent : props.theme.textDim}>
+          {"  " + modeTag()}
         </text>
       </box>
     </box>

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -1,6 +1,6 @@
 import { Component } from "solid-js"
 import type { AppEntry, AppStatus } from "../types"
-import type { ThemeConfig } from "../types"
+import type { Palette } from "../lib/palette"
 
 export interface TabItemProps {
   entry: AppEntry
@@ -8,13 +8,11 @@ export interface TabItemProps {
   isActive: boolean
   isFocused: boolean
   width: number
-  theme: ThemeConfig
+  theme: Palette
   onSelect: () => void
 }
 
-/**
- * Get status indicator character
- */
+/** Status indicator glyph. */
 function getStatusIndicator(status: AppStatus): string {
   switch (status) {
     case "running":
@@ -26,58 +24,47 @@ function getStatusIndicator(status: AppStatus): string {
   }
 }
 
-/**
- * Get status color
- */
-function getStatusColor(status: AppStatus, theme: ThemeConfig): string {
+/** Status color, fully theme-driven (no hardcoded greens/reds). */
+function getStatusColor(status: AppStatus, theme: Palette): string {
   switch (status) {
     case "running":
-      return "#9ece6a" // Green
+      return theme.on
     case "stopped":
-      return theme.muted
+      return theme.off
     case "error":
-      return "#f7768e" // Red
+      return theme.error
   }
 }
 
 export const TabItem: Component<TabItemProps> = (props) => {
   const truncatedName = () => {
-    const maxLen = props.width - 4 // Account for status indicator and padding
+    const maxLen = props.width - 4 // rail + dot + space + breathing room
     if (props.entry.name.length > maxLen) {
       return props.entry.name.slice(0, maxLen - 1) + "…"
     }
     return props.entry.name
   }
 
-  const bgColor = () => {
-    if (props.isActive) {
-      return props.theme.primary
-    }
-    if (props.isFocused) {
-      return props.theme.muted
-    }
-    return props.theme.background
-  }
-
-  const fgColor = () => {
-    if (props.isActive) {
-      return props.theme.background
-    }
-    return props.theme.foreground
-  }
+  // Selection reads as: a 1-col bright accent rail + a slightly lighter row bg.
+  const highlighted = () => props.isActive || props.isFocused
+  const rowBg = () => (highlighted() ? props.theme.surfaceAlt : undefined)
+  const nameColor = () => (props.isActive ? props.theme.accent : props.theme.text)
 
   return (
     <box
       height={1}
       width={props.width}
       flexDirection="row"
+      backgroundColor={rowBg()}
       onMouseDown={props.onSelect}
     >
+      {/* Accent rail — the primary "you are here" tell */}
+      <box width={1} height={1} backgroundColor={props.isFocused ? props.theme.accent : undefined} />
       <text fg={getStatusColor(props.status, props.theme)}>
         {getStatusIndicator(props.status)}
       </text>
       <text> </text>
-      <text fg={fgColor()} bg={bgColor()}>
+      <text fg={nameColor()} bg={rowBg()}>
         {props.isActive ? <b>{truncatedName()}</b> : truncatedName()}
       </text>
     </box>

--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -1,6 +1,7 @@
 import { Component, For, createMemo } from "solid-js"
 import { TabItem } from "./TabItem"
-import type { AppEntry, AppStatus, ThemeConfig } from "../types"
+import type { AppEntry, AppStatus } from "../types"
+import type { Palette } from "../lib/palette"
 
 export interface TabListProps {
   entries: AppEntry[]
@@ -11,13 +12,13 @@ export interface TabListProps {
   width: number
   height: number
   scrollOffset: number
-  theme: ThemeConfig
+  theme: Palette
   onSelect: (id: string) => void
   onAddClick: () => void
 }
 
 export const TabList: Component<TabListProps> = (props) => {
-  const visibleHeight = () => props.height - 2 // Reserve space for header and add button
+  const visibleHeight = () => props.height - 2 // header band + add button
 
   const visibleEntries = createMemo(() => {
     const start = props.scrollOffset
@@ -33,11 +34,10 @@ export const TabList: Component<TabListProps> = (props) => {
       flexDirection="column"
       width={props.width}
       height={props.height}
-      borderStyle="single"
-      borderColor={props.isFocused ? props.theme.primary : props.theme.muted}
+      backgroundColor={props.theme.surface}
     >
-      {/* Header */}
-      <box height={1} width={props.width - 2}>
+      {/* Header band — color-separated, no border */}
+      <box height={1} width={props.width} backgroundColor={props.theme.surfaceAlt} paddingLeft={1}>
         <text fg={props.theme.accent}>
           <b>Apps {hasScrollUp() ? "▲" : " "}{hasScrollDown() ? "▼" : " "}</b>
         </text>
@@ -54,7 +54,7 @@ export const TabList: Component<TabListProps> = (props) => {
                 status={props.getStatus(entry.id)}
                 isActive={entry.id === props.activeTabId}
                 isFocused={props.isFocused && actualIndex() === props.selectedIndex}
-                width={props.width - 2}
+                width={props.width - 1}
                 theme={props.theme}
                 onSelect={() => props.onSelect(entry.id)}
               />
@@ -64,8 +64,8 @@ export const TabList: Component<TabListProps> = (props) => {
       </box>
 
       {/* Add button */}
-      <box height={1} width={props.width - 2} onMouseDown={props.onAddClick}>
-        <text fg={props.theme.muted}>[+ Add]</text>
+      <box height={1} width={props.width} paddingLeft={1} onMouseDown={props.onAddClick}>
+        <text fg={props.theme.textDim}>+ Add</text>
       </box>
     </box>
   )

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,5 +1,6 @@
 import { Component, Show, createEffect } from "solid-js"
-import type { RunningApp, ThemeConfig } from "../types"
+import type { RunningApp } from "../types"
+import type { Palette } from "../lib/palette"
 import { createTerminalFeeder, type TerminalFeedSource } from "../lib/terminal-feed"
 
 export interface TerminalPaneProps {
@@ -7,7 +8,7 @@ export interface TerminalPaneProps {
   isFocused: boolean
   width: number
   height: number
-  theme: ThemeConfig
+  theme: Palette
   onInput?: (data: string) => void
 }
 
@@ -30,13 +31,13 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
       flexGrow={1}
       height={props.height}
       borderStyle="single"
-      borderColor={props.isFocused ? props.theme.primary : props.theme.muted}
+      borderColor={props.isFocused ? props.theme.borderFocus : props.theme.border}
     >
       <Show
         when={props.runningApp}
         fallback={
           <box flexGrow={1} justifyContent="center" alignItems="center">
-            <text fg={props.theme.muted}>
+            <text fg={props.theme.textDim}>
               No app selected. Press 't' to add one.
             </text>
           </box>
@@ -45,11 +46,11 @@ export const TerminalPane: Component<TerminalPaneProps> = (props) => {
         {(app) => (
           <box flexDirection="column" flexGrow={1}>
             {/* Terminal header */}
-            <box height={1} flexDirection="row">
+            <box height={1} flexDirection="row" backgroundColor={props.theme.surface}>
               <text fg={props.theme.accent}>
                 <b>{app().entry.name}</b>
               </text>
-              <text fg={props.theme.muted}>
+              <text fg={props.theme.textDim}>
                 {" "}({app().status})
               </text>
             </box>

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,11 +1,11 @@
 import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
-import type { ThemeConfig } from "../types"
 import { THEME_PRESETS, getCurrentThemeId, type ThemePreset } from "../lib/themes"
+import { resolveTheme, type Palette } from "../lib/palette"
 import { DialogBox } from "./DialogBox"
 
 export interface ThemePickerProps {
-  theme: ThemeConfig
+  theme: Palette
   onSelect: (themeId: string) => void
   onClose: () => void
 }
@@ -80,43 +80,41 @@ export const ThemePicker: Component<ThemePickerProps> = (props) => {
   })
 
   return (
-    <DialogBox theme={props.theme} top="25%" left="25%" width="50%" height={DIALOG_HEIGHT}>
+    <DialogBox theme={props.theme} width="50%" height={DIALOG_HEIGHT}>
+      {/* Title */}
+      <box height={1} paddingLeft={2}>
+        <text fg={props.theme.accent}>
+          <b>Themes</b>
+        </text>
+      </box>
+
       {/* Search input */}
-      <box
-        height={3}
-        flexDirection="row"
-        borderStyle="single"
-        borderColor={props.theme.muted}
-        paddingLeft={1}
-        paddingRight={1}
-      >
-        <box height={1} flexDirection="row" flexGrow={1}>
-          <text fg={props.theme.muted}>{"> "}</text>
-          <input
-            height={1}
-            flexGrow={1}
-            value={query()}
-            focused
-            backgroundColor={props.theme.background}
-            textColor={props.theme.foreground}
-            focusedBackgroundColor={props.theme.background}
-            focusedTextColor={props.theme.foreground}
-            placeholder="Filter themes..."
-            placeholderColor={props.theme.muted}
-            cursorColor={props.theme.accent}
-            onInput={(value) => setQuery(value)}
-            onSubmit={() => handleSelect(filteredThemes()[selectedIndex()])}
-          />
-        </box>
+      <box height={1} flexDirection="row" paddingLeft={2} paddingRight={2}>
+        <text fg={props.theme.textDim}>{"› "}</text>
+        <input
+          height={1}
+          flexGrow={1}
+          value={query()}
+          focused
+          backgroundColor={props.theme.surface}
+          textColor={props.theme.text}
+          focusedBackgroundColor={props.theme.surface}
+          focusedTextColor={props.theme.text}
+          placeholder="Filter themes..."
+          placeholderColor={props.theme.textDim}
+          cursorColor={props.theme.accent}
+          onInput={(value) => setQuery(value)}
+          onSubmit={() => handleSelect(filteredThemes()[selectedIndex()])}
+        />
       </box>
 
       {/* Theme list */}
-      <box flexDirection="column" flexGrow={1} overflow="hidden">
+      <box flexDirection="column" flexGrow={1} overflow="hidden" paddingRight={2}>
         <Show
           when={filteredThemes().length > 0}
           fallback={
             <box flexGrow={1} justifyContent="center" alignItems="center">
-              <text fg={props.theme.muted}>No matching themes.</text>
+              <text fg={props.theme.textDim}>No matching themes.</text>
             </box>
           }
         >
@@ -125,22 +123,22 @@ export const ThemePicker: Component<ThemePickerProps> = (props) => {
               const actualIndex = () => scrollOffset() + index()
               const isSelected = () => actualIndex() === selectedIndex()
               const isCurrent = () => theme.id === currentThemeId()
+              const swatch = createMemo(() => resolveTheme(theme))
               return (
-                <box height={1} flexDirection="row">
-                  <text
-                    fg={
-                      isSelected()
-                        ? props.theme.background
-                        : isCurrent()
-                          ? props.theme.accent
-                          : props.theme.foreground
-                    }
-                    bg={isSelected() ? props.theme.primary : undefined}
-                  >
-                    {isCurrent() ? " [*] " : " [ ] "}
-                    {theme.name.padEnd(18)}
-                    {theme.id}
+                <box height={1} flexDirection="row" backgroundColor={isSelected() ? props.theme.surfaceAlt : undefined}>
+                  {/* accent rail */}
+                  <box width={1} height={1} backgroundColor={isSelected() ? props.theme.accent : undefined} />
+                  <text fg={isCurrent() ? props.theme.accent : props.theme.textDim}>
+                    {isCurrent() ? " ✓ " : "   "}
                   </text>
+                  <text fg={isSelected() || isCurrent() ? props.theme.text : props.theme.textDim}>
+                    {theme.name.padEnd(18)}
+                  </text>
+                  {/* live swatch of the resolved ramp */}
+                  <text fg={swatch().accent}>●</text>
+                  <text fg={swatch().on}>●</text>
+                  <text fg={swatch().warn}>●</text>
+                  <text fg={swatch().error}>●</text>
                 </box>
               )
             }}
@@ -149,19 +147,21 @@ export const ThemePicker: Component<ThemePickerProps> = (props) => {
       </box>
 
       {/* Footer hints */}
-      <box
-        height={3}
-        borderStyle="single"
-        borderColor={props.theme.muted}
-        paddingLeft={1}
-        paddingRight={1}
-      >
-        <box height={1}>
-          <text fg={props.theme.muted}>
-            Enter:Select | Esc:Close | Up/Down:Navigate | j/k:Navigate
-          </text>
-        </box>
+      <box height={1} flexDirection="row" paddingLeft={2}>
+        <Hint theme={props.theme} keyLabel="↵" desc="select" />
+        <Hint theme={props.theme} keyLabel="↑↓" desc="nav" />
+        <Hint theme={props.theme} keyLabel="esc" desc="close" />
       </box>
     </DialogBox>
   )
 }
+
+const Hint: Component<{ theme: Palette; keyLabel: string; desc: string }> = (props) => (
+  <>
+    <text fg={props.theme.accent}>
+      {"  "}
+      <b>{props.keyLabel}</b>
+    </text>
+    <text fg={props.theme.textDim}>{" " + props.desc}</text>
+  </>
+)

--- a/src/components/WindowBar.tsx
+++ b/src/components/WindowBar.tsx
@@ -1,27 +1,25 @@
 import { Component, For } from "solid-js"
-import type { ThemeConfig, WindowState } from "../types"
+import type { WindowState } from "../types"
+import type { Palette } from "../lib/palette"
 
 export interface WindowBarProps {
   windows: WindowState[]
   activeWindowId: string | null
-  theme: ThemeConfig
+  theme: Palette
   onSelect: (id: string) => void
 }
 
 export const WindowBar: Component<WindowBarProps> = (props) => {
   return (
-    <box height={1} flexDirection="row" backgroundColor={props.theme.muted}>
+    <box height={1} flexDirection="row" backgroundColor={props.theme.surfaceAlt}>
       <For each={props.windows}>
         {(window, index) => {
           const isActive = () => window.id === props.activeWindowId
           const label = () => ` ${index() + 1}:${window.title} `
           return (
-            <box onMouseDown={() => props.onSelect(window.id)}>
-              <text
-                fg={isActive() ? props.theme.background : props.theme.foreground}
-                bg={isActive() ? props.theme.primary : props.theme.muted}
-              >
-                {label()}
+            <box onMouseDown={() => props.onSelect(window.id)} backgroundColor={isActive() ? props.theme.surface : undefined}>
+              <text fg={isActive() ? props.theme.accent : props.theme.textDim}>
+                {isActive() ? <b>{label()}</b> : label()}
               </text>
             </box>
           )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -100,9 +100,15 @@ async function main() {
     // Render the app using opentui/solid
     debugLog("[init] Calling render()...")
     try {
-      await render(() => (
-        <App config={config} sessionClient={sessionClient} startWithAddModal={options.add} />
-      ))
+      // exitOnCtrlC:false — opentui's built-in handler would call destroy() on
+      // Ctrl+C regardless of our keyboard handler. We manage Ctrl+C ourselves so
+      // it passes through to the focused PTY (and is ignored in tabs/manager mode).
+      await render(
+        () => (
+          <App config={config} sessionClient={sessionClient} startWithAddModal={options.add} />
+        ),
+        { exitOnCtrlC: false },
+      )
       debugLog("[init] render() completed")
     } catch (renderError) {
       debugLog(`[init] ERROR in render(): ${renderError}`)

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -9,6 +9,7 @@ function makeConfig(apps: Config["apps"]): Config {
     theme: defaultTheme,
     tab_width: 20,
     layout: "classic",
+    focus_on_launch: true,
     apps,
     session: { persist: true },
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,14 +21,14 @@ export interface LoadConfigResult {
 const LOCAL_CONFIG_PATH = "./tuidoscope.yaml"
 
 // Zod schema for validation
-// Default theme: Night Owl (https://github.com/sdras/night-owl-vscode-theme)
-// Ghostty port: https://github.com/m1yon/ghostty-night-owl
+// Default theme: Graphite (tight dark surface ramp + sparse cyan accent).
+// The rich palette is derived at runtime in src/lib/palette.ts.
 const ThemeSchema = z.object({
-  primary: z.string().default("#82aaff"),     // Blue - selections, highlights
-  background: z.string().default("#011627"),  // Deep dark blue
-  foreground: z.string().default("#d6deeb"),  // Light gray-blue text
-  accent: z.string().default("#7fdbca"),      // Cyan/teal - active indicators
-  muted: z.string().default("#637777"),       // Gray-blue for inactive elements
+  primary: z.string().default("#7fd1ff"),     // Cyan - selections, highlights
+  background: z.string().default("#111315"),  // Near-black graphite
+  foreground: z.string().default("#f2f4f6"),  // Neutral white text
+  accent: z.string().default("#7fd1ff"),      // Cyan - active indicators
+  muted: z.string().default("#9aa4af"),       // Cool gray for inactive elements
 })
 
 const AppEntrySchema = z.object({
@@ -53,6 +53,8 @@ const ConfigSchema = z.object({
   theme: ThemeSchema.default({}),
   tab_width: z.number().default(20),
   layout: z.enum(["classic", "zellij"]).default("classic"),
+  // Move focus into the app's pane automatically when it launches.
+  focus_on_launch: z.boolean().default(true),
   apps: z.array(AppEntrySchema).default([]),
   session: SessionSchema.default({}),
 })

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -1,0 +1,83 @@
+import type { ThemeConfig } from "../types"
+
+/**
+ * The resolved palette consumed by every UI component.
+ *
+ * A theme on disk is only 5 tokens (primary/background/foreground/accent/muted).
+ * At runtime we derive a richer "graphite" ramp from those — a tight dark surface
+ * ladder (bg -> surface -> surfaceAlt are "whispers apart"), a sparse accent, and
+ * desaturated pastel semantics. The 5 base tokens are kept as aliases so the
+ * resolved palette is a superset of ThemeConfig (no migration, drop-in for old props).
+ *
+ * Design language ported from shuvbot-skills/tui/src/tui/theme.ts: "rich but calm".
+ */
+export interface Palette extends ThemeConfig {
+  // surface ramp (keep the steps TIGHT — this is what reads as calm)
+  bg: string // app background
+  surface: string // panels, headers (1 shade up)
+  surfaceAlt: string // chrome bars, selected row, modals (1 shade up again)
+  // structure
+  border: string // dim resting borders / separators
+  borderFocus: string // focused pane / modal border (bright)
+  accentMuted: string // selected-cell bg, desaturated accent
+  // text
+  text: string // primary text (= foreground)
+  textDim: string // secondary / inactive text (= muted)
+  // semantic status (desaturated on purpose)
+  on: string // running / ok (soft green)
+  off: string // stopped / recedes (= muted)
+  warn: string // warning (muted amber)
+  error: string // error / failed (soft red)
+}
+
+// Functional status colors. These carry meaning rather than brand, so they stay
+// fixed pastels across every theme (replaces the old hardcoded greens/reds).
+const SEMANTICS = {
+  on: "#88d39b",
+  warn: "#e6cf98",
+  error: "#f0a0a0",
+} as const
+
+/**
+ * Per-channel lerp between two hex colors. ratio=0 -> bg, ratio=1 -> fg.
+ * Expects 6-digit `#rrggbb`. (ported from shuvbot-skills/tui/src/tui/theme.ts)
+ */
+export function blendHex(fg: string, bg: string, ratio: number): string {
+  const channels = (h: string) => [1, 3, 5].map((i) => parseInt(h.slice(i, i + 2), 16))
+  const a = channels(fg)
+  const b = channels(bg)
+  const m = a.map((x, i) => Math.round(b[i]! + (x - b[i]!) * ratio))
+  return "#" + m.map((x) => Math.max(0, Math.min(255, x)).toString(16).padStart(2, "0")).join("")
+}
+
+// Cache resolved palettes by base-token identity so we don't re-derive per render.
+const cache = new Map<string, Palette>()
+
+/** Derive the full graphite-style ramp from a 5-token theme. */
+export function resolveTheme(theme: ThemeConfig): Palette {
+  const key = `${theme.primary}|${theme.background}|${theme.foreground}|${theme.accent}|${theme.muted}`
+  const hit = cache.get(key)
+  if (hit) return hit
+
+  const bg = theme.background
+  const fg = theme.foreground
+
+  const palette: Palette = {
+    ...theme,
+    bg,
+    surface: blendHex(fg, bg, 0.04),
+    surfaceAlt: blendHex(fg, bg, 0.08),
+    border: blendHex(fg, bg, 0.18),
+    borderFocus: blendHex(fg, bg, 0.82),
+    accentMuted: blendHex(theme.accent, bg, 0.3),
+    text: fg,
+    textDim: theme.muted,
+    on: SEMANTICS.on,
+    off: theme.muted,
+    warn: SEMANTICS.warn,
+    error: SEMANTICS.error,
+  }
+
+  cache.set(key, palette)
+  return palette
+}

--- a/src/lib/pty.ts
+++ b/src/lib/pty.ts
@@ -176,7 +176,11 @@ export function spawnPty(
     ...entry.env,
   }
 
-  const useScript = process.platform !== "win32" && !process.env.TUIDISCOPE_NO_SCRIPT
+  // Spawn the command directly: Bun.Terminal already provides a real PTY, so the
+  // old `script` wrapper was a redundant second PTY that never forwarded
+  // window-size (TIOCSWINSZ) changes to the inner terminal — which broke live
+  // resize of embedded apps. Opt back into the wrapper with TUIDISCOPE_USE_SCRIPT=1.
+  const useScript = process.platform !== "win32" && !!process.env.TUIDISCOPE_USE_SCRIPT
   const entryCommand = buildEntryCommand(entry)
   const commandString = buildCommandString(entryCommand)
   const { program, args } = parseCommand(entryCommand)

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -16,6 +16,7 @@ describe("session persistence", () => {
       theme: defaultTheme,
       tab_width: 20,
       layout: "classic",
+      focus_on_launch: true,
       apps: [],
       session: { persist: true, file: sessionFile },
     }
@@ -67,6 +68,7 @@ describe("session persistence", () => {
       theme: defaultTheme,
       tab_width: 20,
       layout: "classic",
+      focus_on_launch: true,
       apps: [],
       session: { persist: true, file: sessionFile },
     }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,12 +1,13 @@
 import type { ThemeConfig } from "../types"
 
-// Default Night Owl-inspired theme
+// Default Graphite theme: a tight dark surface ramp + sparse cyan accent.
+// See src/lib/palette.ts for how the rich ramp is derived from these 5 tokens.
 export const defaultTheme: ThemeConfig = {
-  primary: "#82aaff",     // Blue - selections, highlights
-  background: "#011627",  // Deep dark blue
-  foreground: "#d6deeb",  // Light gray-blue text
-  accent: "#7fdbca",      // Cyan/teal - active indicators (was purple)
-  muted: "#637777",       // Gray-blue for inactive elements
+  primary: "#7fd1ff",     // Cyan - selections, highlights
+  background: "#111315",  // Near-black graphite
+  foreground: "#f2f4f6",  // Neutral white text
+  accent: "#7fd1ff",      // Cyan - active indicators
+  muted: "#9aa4af",       // Cool gray for inactive elements
 }
 
 /**

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -28,8 +28,8 @@ describe("isValidHexColor", () => {
 })
 
 describe("THEME_PRESETS", () => {
-  test("contains 8 theme presets", () => {
-    expect(THEME_PRESETS.length).toBe(8)
+  test("contains 9 theme presets", () => {
+    expect(THEME_PRESETS.length).toBe(9)
   })
 
   test("all presets have valid hex colors for all 5 required properties", () => {
@@ -54,13 +54,14 @@ describe("THEME_PRESETS", () => {
     expect(uniqueNames.size).toBe(names.length)
   })
 
-  test("night-owl is the first (default) preset", () => {
-    expect(THEME_PRESETS[0].id).toBe("night-owl")
-    expect(THEME_PRESETS[0].name).toBe("Night Owl")
+  test("graphite is the first (default) preset", () => {
+    expect(THEME_PRESETS[0].id).toBe("graphite")
+    expect(THEME_PRESETS[0].name).toBe("Graphite")
   })
 
   test("includes expected popular themes", () => {
     const expectedThemes = [
+      "graphite",
       "night-owl",
       "dracula",
       "nord",

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -12,6 +12,15 @@ export function isValidHexColor(color: string): boolean {
 
 export const THEME_PRESETS: ThemePreset[] = [
   {
+    id: "graphite",
+    name: "Graphite",
+    primary: "#7fd1ff",     // Cyan - selections, highlights
+    background: "#111315",  // Near-black graphite
+    foreground: "#f2f4f6",  // Neutral white text
+    accent: "#7fd1ff",      // Cyan - active indicators
+    muted: "#9aa4af",       // Cool gray for inactive elements
+  },
+  {
     id: "night-owl",
     name: "Night Owl",
     primary: "#82aaff",

--- a/src/lib/width-layout.ts
+++ b/src/lib/width-layout.ts
@@ -1,0 +1,42 @@
+// Responsive width handling: a coarse layout mode + a self-fitting keybind bar.
+// Modeled on shuvbot-skills/tui/src/tui/{layout.ts,Footer.tsx}. The status bar
+// renders the widest hint tier that fits the terminal, downgrading as it narrows
+// so hints never wrap onto a second line.
+
+export type WidthMode = "full" | "compact" | "minimum"
+
+// Below COMPACT_MAX -> compact; below MINIMUM_MAX -> minimum (sidebar collapses).
+export const COMPACT_MAX = 80
+export const MINIMUM_MAX = 56
+
+export function widthMode(cols: number): WidthMode {
+  if (cols < MINIMUM_MAX) return "minimum"
+  if (cols < COMPACT_MAX) return "compact"
+  return "full"
+}
+
+export interface Hint {
+  key: string
+  label: string
+}
+
+// Rendered width of a hint set: "key label" pairs joined by two spaces.
+export function hintsWidth(hints: Hint[]): number {
+  return hints.reduce(
+    (sum, h, i) => sum + h.key.length + 1 + h.label.length + (i > 0 ? 2 : 0),
+    0,
+  )
+}
+
+/**
+ * Pick the widest hint tier that fits within `cols` (minus a small reserve for
+ * the center message + right focus tag). `tiers` is ordered widest-first; the
+ * last tier is the floor when nothing else fits.
+ */
+export function fitHints(cols: number, tiers: Hint[][], reserve = 22): Hint[] {
+  const budget = Math.max(0, cols - reserve)
+  for (const tier of tiers) {
+    if (hintsWidth(tier) <= budget) return tier
+  }
+  return tiers[tiers.length - 1] ?? []
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,8 @@ export interface Config {
   theme: ThemeConfig
   tab_width: number
   layout: LayoutMode
+  /** Move keyboard focus into the app's pane automatically when it launches. */
+  focus_on_launch: boolean
   apps: AppEntryConfig[]
   session: SessionConfig
 }


### PR DESCRIPTION
## Summary

Reskins the tuidoscope UI to the "rich but calm" **graphite** design language (from shuvbot-skills), adds a `focus_on_launch` option, and fixes two embedded-terminal bugs.

### UI reskin (`feat`)
- **Runtime palette** (`src/lib/palette.ts`): derives a rich 13-token ramp (surface ladder, desaturated semantics) from the stored 5-token theme via `blendHex`. Components consume `theme: Palette` — a superset of `ThemeConfig`, so **no config migration**. Hardcoded status colors are gone (now `palette.on/off/error`).
- **Themes**: new **Graphite** default; the existing 8 presets stay and each gets the derived ramp. ThemePicker shows live swatches.
- **Responsive** (`src/lib/width-layout.ts`): `full`/`compact`/`minimum` modes, a self-fitting keybind bar that downgrades to fit, and sidebar collapse at minimum width.
- **Chrome**: borderless color-separated bars; terminal-pane frame brightens on focus; rounded, centered/clamped modals (`DialogBox`); two-column help.
- **`focus_on_launch`** config option (default `true`): move focus into a pane's terminal automatically when its app launches.

### Fixes
- **Resize passthrough**: spawn embedded apps directly via `Bun.Terminal` instead of the `script` wrapper, which created a redundant second PTY that never forwarded `TIOCSWINSZ` — so window resizes never reached embedded apps. Opt back in with `TUIDISCOPE_USE_SCRIPT=1`.
- **Ctrl+C passthrough**: render with `exitOnCtrlC: false` so our keyboard handler owns Ctrl+C — it passes through to the focused PTY and is ignored in tabs/manager focus (quit stays `q`/`Q`).

## Verification
- `bun run typecheck` clean; `bun test` → 46 pass / 0 fail
- Driven live in a PTY: graphite + theme switching, full/compact/minimum widths, accent-rail selection, rounded modals; htop/btop/shell reflow on resize; Ctrl+C interrupts the embedded app without quitting tuidoscope.

## Commits
1. `feat: reskin UI to graphite design language`
2. `fix: forward window resize to embedded terminals`
3. `fix: pass Ctrl+C through to the focused pane instead of quitting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)