### PR TITLE
fix: don't seed extra shell or orphan apps on layout switch (#11, #12)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1009,9 +1009,11 @@ export const App: Component<AppProps> = (props) => {
   // Capture the running app entries (deduped) plus the active one so they can be
   // re-created after the server restarts in the other layout.
   const captureRunningEntries = (): { entries: AppEntry[]; activeEntryId: string | null } => {
+    let entries: AppEntry[]
+    let activeEntryId: string | null
     if (isPanesLayout()) {
       const seen = new Set<string>()
-      const entries: AppEntry[] = []
+      entries = []
       for (const pane of windowsStore.store.runningPanes.values()) {
         if (seen.has(pane.entry.id)) continue
         seen.add(pane.entry.id)
@@ -1019,12 +1021,20 @@ export const App: Component<AppProps> = (props) => {
       }
       const activePaneId = windowsStore.store.activePaneId
       const activePane = activePaneId ? windowsStore.getRunningPane(activePaneId) : undefined
-      return { entries, activeEntryId: activePane?.entry.id ?? null }
+      activeEntryId = activePane?.entry.id ?? null
+    } else {
+      entries = Array.from(tabsStore.store.runningApps.values()).map((app) => app.entry)
+      activeEntryId = tabsStore.store.activeTabId
     }
-    return {
-      entries: Array.from(tabsStore.store.runningApps.values()).map((app) => app.entry),
-      activeEntryId: tabsStore.store.activeTabId,
-    }
+    // Only replay apps that exist in the configured app list. A running pane
+    // whose entry isn't configured (e.g. the panes server's default "shell"
+    // window) has no home in the tabs sidebar, so replaying it would leave an
+    // unreachable running app (#11). Dropping it keeps every replayed app
+    // addressable; the orphaned process dies with the old server anyway.
+    const configured = entries.filter((entry) => appsStore.getEntry(entry.id) !== undefined)
+    const activeConfigured =
+      activeEntryId && appsStore.getEntry(activeEntryId) ? activeEntryId : (configured[0]?.id ?? null)
+    return { entries: configured, activeEntryId: activeConfigured }
   }
 
   // Point the app at a freshly-connected client, clearing stale layout state so
@@ -1046,6 +1056,9 @@ export const App: Component<AppProps> = (props) => {
     try {
       const back = await reconnectSessionClient(layout)
       props.config.layout = layout
+      // Persist the layout we actually recovered into, so a cold start doesn't
+      // launch in the target layout we failed to reach.
+      await saveConfig(props.config)
       adoptFreshClient(back, layout)
       uiStore.showTemporaryMessage("Switch failed — restored previous layout")
     } catch (error) {
@@ -1086,7 +1099,13 @@ export const App: Component<AppProps> = (props) => {
       props.config.layout = target
       await saveConfig(props.config)
 
-      const next = await reconnectSessionClient(target)
+      // When there are apps to replay, suppress the panes server's default
+      // shell window so the switch doesn't leave an extra unwanted window
+      // alongside them (#12). With nothing to replay, let it seed so the
+      // workspace isn't empty.
+      const next = await reconnectSessionClient(target, {
+        seedDefaultWindow: entries.length === 0,
+      })
       adoptFreshClient(next, target)
 
       // Replay the captured entries once the new server is ready. If it never

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,7 @@ async function main() {
     // Handle --server
     if (options.server) {
       debugLog("[init] Starting session server")
-      await startSessionServer(options.layout)
+      await startSessionServer(options.layout, { seedDefaultWindow: !options.noDefaultWindow })
       return
     }
     

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -9,6 +9,7 @@ export interface CLIOptions {
   debug: boolean
   add: boolean
   server: boolean
+  noDefaultWindow: boolean
   shutdown: boolean
   layout?: "tabs" | "panes"
   unknown: string[]
@@ -60,6 +61,7 @@ export function parseArgs(argv: string[]): CLIOptions {
     debug: false,
     add: false,
     server: false,
+    noDefaultWindow: false,
     shutdown: false,
     layout: undefined,
     unknown: [],
@@ -102,6 +104,9 @@ export function parseArgs(argv: string[]): CLIOptions {
         break
       case "--server":
         options.server = true
+        break
+      case "--no-default-window":
+        options.noDefaultWindow = true
         break
       case "--shutdown":
         options.shutdown = true

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -165,7 +165,10 @@ async function connectSocket(): Promise<net.Socket> {
   })
 }
 
-async function spawnServerProcess(layout?: LayoutMode): Promise<void> {
+async function spawnServerProcess(
+  layout?: LayoutMode,
+  options?: { seedDefaultWindow?: boolean }
+): Promise<void> {
   // Bun.main is a stable way to find the actual entrypoint even when the CLI is
   // invoked via a symlink (e.g. `tui`) where process.argv[1] may not end in .js.
   const candidates = [
@@ -177,6 +180,9 @@ async function spawnServerProcess(layout?: LayoutMode): Promise<void> {
   const args = entry ? [entry, "--server"] : ["--server"]
   if (layout) {
     args.push("--layout", layout)
+  }
+  if (options?.seedDefaultWindow === false) {
+    args.push("--no-default-window")
   }
 
   const proc = Bun.spawn([process.execPath, ...args], {
@@ -234,7 +240,10 @@ export async function connectSessionClient(options?: { layout?: LayoutMode }): P
   }
 }
 
-export async function reconnectSessionClient(layout: LayoutMode): Promise<SessionClient> {
+export async function reconnectSessionClient(
+  layout: LayoutMode,
+  options?: { seedDefaultWindow?: boolean }
+): Promise<SessionClient> {
   if (existsSync(SOCKET_PATH)) {
     try {
       await unlink(SOCKET_PATH)
@@ -242,7 +251,7 @@ export async function reconnectSessionClient(layout: LayoutMode): Promise<Sessio
       debugLog(`[client] reconnect: failed to remove stale socket: ${unlinkError}`)
     }
   }
-  await spawnServerProcess(layout)
+  await spawnServerProcess(layout, options)
   const socket = await waitForServer()
   return new SessionClient(socket)
 }

--- a/src/lib/session-server.ts
+++ b/src/lib/session-server.ts
@@ -108,13 +108,16 @@ function resolveSessionEntry(ref: string | SessionAppRef, entries: AppEntry[]): 
   )
 }
 
-export async function startSessionServer(layoutOverride?: LayoutMode): Promise<void> {
+export async function startSessionServer(
+  layoutOverride?: LayoutMode,
+  options?: { seedDefaultWindow?: boolean }
+): Promise<void> {
   const { config } = await loadConfig()
   if (layoutOverride) {
     config.layout = layoutOverride
   }
   if (config.layout === "panes") {
-    await startPanesSessionServer(config)
+    await startPanesSessionServer(config, options)
     return
   }
   initSessionPath(config)
@@ -547,7 +550,10 @@ export async function startSessionServer(layoutOverride?: LayoutMode): Promise<v
   process.on("SIGINT", () => void shutdown())
 }
 
-async function startPanesSessionServer(config: Config): Promise<void> {
+async function startPanesSessionServer(
+  config: Config,
+  options?: { seedDefaultWindow?: boolean }
+): Promise<void> {
   initSessionPath(config)
 
   const entries = config.apps.map(configToEntry)
@@ -1220,7 +1226,10 @@ async function startPanesSessionServer(config: Config): Promise<void> {
     }
   }
 
-  if (!windows.size) {
+  // Seed a default shell window only when there's nothing else to show. The
+  // client suppresses this (via --no-default-window) when a layout switch is
+  // about to replay apps, so the switch doesn't leave an extra shell (#12).
+  if (!windows.size && (options?.seedDefaultWindow ?? true)) {
     const shellEntry = entries.find((entry) => entry.id === "shell") ?? buildDefaultShellEntry()
     createWindow(shellEntry)
   }


### PR DESCRIPTION
## Summary

Fixes the two layout-switch UX bugs found during the dogfood pass on #10.

- **Fixes #12** — switching tabs→panes left an extra default `Shell` window beside the replayed apps. A `seedDefaultWindow` flag is threaded client→server (`reconnectSessionClient` → `--no-default-window` → `startPanesSessionServer`); the panes server now seeds its default shell **only when there are no apps to replay**. Switching with apps running shows just those apps; switching into an empty panes workspace still gets a shell (so it isn't blank).
- **Fixes #11** — after panes→tabs, a running pane with no tab home (the default `shell`, which isn't a configured app) was carried into tabs as an active-but-unreachable running app. `captureRunningEntries()` now replays only entries present in the configured app list, so every replayed app is addressable from the sidebar.

Also: `recoverLayout()` now persists the layout it recovered into, so a failed switch doesn't leave the on-disk config pointing at the layout it couldn't reach.

## Review

Adversarially reviewed (3 independent reviewers, all "solid", 0 high/med correctness bugs). One related, **pre-existing** issue surfaced — autostart apps can produce duplicate windows on a tabs→panes switch — which the reviewers flagged as out-of-scope; filed separately as a follow-up.

## Testing

- `tsc --noEmit` clean · `bun test` 51/51 · `bun run build` OK.
- Verified live (tmux) across the full matrix: tabs↔panes with {0, N} apps — no extra shell, no orphan, default shell still seeded on empty→panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
