### PR TITLE
fix: don't autostart on layout switch — replay is authoritative (#14)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1054,6 +1054,9 @@ export const App: Component<AppProps> = (props) => {
   // the UI stays usable (running apps are not replayed here).
   const recoverLayout = async (layout: LayoutMode) => {
     try {
+      // Recovery is a fresh fallback with no replay, so let the new server
+      // autostart configured apps — unlike switchLayout, which suppresses
+      // autostart (autostart: false) and replays the exact running set itself.
       const back = await reconnectSessionClient(layout)
       props.config.layout = layout
       // Persist the layout we actually recovered into, so a cold start doesn't
@@ -1105,6 +1108,10 @@ export const App: Component<AppProps> = (props) => {
       // workspace isn't empty.
       const next = await reconnectSessionClient(target, {
         seedDefaultWindow: entries.length === 0,
+        // The replay below is the single source of truth on a switch, so don't
+        // let the new server also autostart configured apps — that would
+        // duplicate any autostart app being replayed (#14).
+        autostart: false,
       })
       adoptFreshClient(next, target)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,10 @@ async function main() {
     // Handle --server
     if (options.server) {
       debugLog("[init] Starting session server")
-      await startSessionServer(options.layout, { seedDefaultWindow: !options.noDefaultWindow })
+      await startSessionServer(options.layout, {
+        seedDefaultWindow: !options.noDefaultWindow,
+        autostart: !options.noAutostart,
+      })
       return
     }
     

--- a/src/lib/cli.test.ts
+++ b/src/lib/cli.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { parseArgs } from "./cli"
+
+// parseArgs slices off the first two argv entries (runtime + script path).
+const parse = (...args: string[]) => parseArgs(["bun", "index.tsx", ...args])
+
+describe("parseArgs", () => {
+  test("defaults: internal flags off, no unknowns", () => {
+    const o = parse()
+    expect(o.server).toBe(false)
+    expect(o.noDefaultWindow).toBe(false)
+    expect(o.noAutostart).toBe(false)
+    expect(o.layout).toBeUndefined()
+    expect(o.unknown).toEqual([])
+  })
+
+  test("--server", () => {
+    expect(parse("--server").server).toBe(true)
+  })
+
+  // Internal flags used by the client when respawning the server during a
+  // layout switch — must parse and must NOT land in unknown[].
+  test("--no-default-window sets the flag and is not unknown", () => {
+    const o = parse("--no-default-window")
+    expect(o.noDefaultWindow).toBe(true)
+    expect(o.unknown).toEqual([])
+  })
+
+  test("--no-autostart sets the flag and is not unknown", () => {
+    const o = parse("--no-autostart")
+    expect(o.noAutostart).toBe(true)
+    expect(o.unknown).toEqual([])
+  })
+
+  test("--layout accepts current values", () => {
+    expect(parse("--layout", "tabs").layout).toBe("tabs")
+    expect(parse("--layout", "panes").layout).toBe("panes")
+  })
+
+  test("--layout normalizes legacy aliases", () => {
+    expect(parse("--layout", "classic").layout).toBe("tabs")
+    expect(parse("--layout", "zellij").layout).toBe("panes")
+  })
+
+  test("--layout=value form works", () => {
+    expect(parse("--layout=panes").layout).toBe("panes")
+    expect(parse("--layout=zellij").layout).toBe("panes")
+  })
+
+  test("invalid --layout value is reported as unknown", () => {
+    const o = parse("--layout", "sideways")
+    expect(o.layout).toBeUndefined()
+    expect(o.unknown).toContain("--layout")
+  })
+
+  test("unknown flags are collected", () => {
+    expect(parse("--bogus").unknown).toContain("--bogus")
+  })
+
+  test("a full switch-respawn invocation parses cleanly", () => {
+    const o = parse("--server", "--layout", "panes", "--no-default-window", "--no-autostart")
+    expect(o.server).toBe(true)
+    expect(o.layout).toBe("panes")
+    expect(o.noDefaultWindow).toBe(true)
+    expect(o.noAutostart).toBe(true)
+    expect(o.unknown).toEqual([])
+  })
+})

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -10,6 +10,7 @@ export interface CLIOptions {
   add: boolean
   server: boolean
   noDefaultWindow: boolean
+  noAutostart: boolean
   shutdown: boolean
   layout?: "tabs" | "panes"
   unknown: string[]
@@ -62,6 +63,7 @@ export function parseArgs(argv: string[]): CLIOptions {
     add: false,
     server: false,
     noDefaultWindow: false,
+    noAutostart: false,
     shutdown: false,
     layout: undefined,
     unknown: [],
@@ -107,6 +109,9 @@ export function parseArgs(argv: string[]): CLIOptions {
         break
       case "--no-default-window":
         options.noDefaultWindow = true
+        break
+      case "--no-autostart":
+        options.noAutostart = true
         break
       case "--shutdown":
         options.shutdown = true

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -167,7 +167,7 @@ async function connectSocket(): Promise<net.Socket> {
 
 async function spawnServerProcess(
   layout?: LayoutMode,
-  options?: { seedDefaultWindow?: boolean }
+  options?: { seedDefaultWindow?: boolean; autostart?: boolean }
 ): Promise<void> {
   // Bun.main is a stable way to find the actual entrypoint even when the CLI is
   // invoked via a symlink (e.g. `tui`) where process.argv[1] may not end in .js.
@@ -183,6 +183,9 @@ async function spawnServerProcess(
   }
   if (options?.seedDefaultWindow === false) {
     args.push("--no-default-window")
+  }
+  if (options?.autostart === false) {
+    args.push("--no-autostart")
   }
 
   const proc = Bun.spawn([process.execPath, ...args], {
@@ -242,7 +245,7 @@ export async function connectSessionClient(options?: { layout?: LayoutMode }): P
 
 export async function reconnectSessionClient(
   layout: LayoutMode,
-  options?: { seedDefaultWindow?: boolean }
+  options?: { seedDefaultWindow?: boolean; autostart?: boolean }
 ): Promise<SessionClient> {
   if (existsSync(SOCKET_PATH)) {
     try {

--- a/src/lib/session-server.ts
+++ b/src/lib/session-server.ts
@@ -110,7 +110,7 @@ function resolveSessionEntry(ref: string | SessionAppRef, entries: AppEntry[]): 
 
 export async function startSessionServer(
   layoutOverride?: LayoutMode,
-  options?: { seedDefaultWindow?: boolean }
+  options?: { seedDefaultWindow?: boolean; autostart?: boolean }
 ): Promise<void> {
   const { config } = await loadConfig()
   if (layoutOverride) {
@@ -518,7 +518,7 @@ export async function startSessionServer(
     const session = await restoreSession()
 
     for (const entry of entries) {
-      if (entry.autostart) {
+      if ((options?.autostart ?? true) && entry.autostart) {
         startApp(entry)
       }
     }
@@ -540,7 +540,7 @@ export async function startSessionServer(
     }
   } else {
     for (const entry of entries) {
-      if (entry.autostart) {
+      if ((options?.autostart ?? true) && entry.autostart) {
         startApp(entry)
       }
     }
@@ -552,7 +552,7 @@ export async function startSessionServer(
 
 async function startPanesSessionServer(
   config: Config,
-  options?: { seedDefaultWindow?: boolean }
+  options?: { seedDefaultWindow?: boolean; autostart?: boolean }
 ): Promise<void> {
   initSessionPath(config)
 
@@ -1205,7 +1205,7 @@ async function startPanesSessionServer(
     }
 
     for (const entry of entries) {
-      if (entry.autostart && !startedEntries.has(entry.id)) {
+      if ((options?.autostart ?? true) && entry.autostart && !startedEntries.has(entry.id)) {
         createWindow(entry, { makeActive: false })
       }
     }
@@ -1220,7 +1220,7 @@ async function startPanesSessionServer(
     }
   } else {
     for (const entry of entries) {
-      if (entry.autostart) {
+      if ((options?.autostart ?? true) && entry.autostart) {
         createWindow(entry, { makeActive: false })
       }
     }


### PR DESCRIPTION
## Summary

**Fixes #14.** On a runtime layout switch, the client replays the captured running apps — but the freshly-spawned server *also* autostarted configured `autostart: true` apps. In panes mode (`createWindow` mints a fresh window id, no dedup), a running autostart app appeared in **two** windows. (Tabs was safe: `startApp` dedups by `entry.id`.)

Threads an `autostart` flag client→server, mirroring the existing `seedDefaultWindow`/`--no-default-window` plumbing: `switchLayout` passes `autostart: false` → `--no-autostart` → the switch-spawned server skips all four autostart loops (classic + panes, persist + non-persist), making the client's replay the single source of truth. Normal launches and the failure-recovery path keep autostarting (flag defaults on). Bonus: a stopped autostart app no longer resurrects on a clean switch.

## Review

Two independent Opus reviewers, both **"solid"** — all four loops confirmed guarded, session-restore loops correctly left unguarded (no-ops on a cleared switch), normal startup preserved, plumbing type-clean. Applied their two suggestions: a clarifying comment on `recoverLayout` and a new `cli.test.ts`.

## Testing

- `tsc --noEmit` clean · `bun test` **61/61** (+10 new `parseArgs` tests) · `bun run build` OK.
- Verified live (tmux): an `autostart: true` app auto-starts on normal launch **and** appears exactly once after a `tabs→panes` switch (was two before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
