### PR TITLE
feat: scroll the horizontal task bar to keep the active item visible (#17)

### DIFF
--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -2,6 +2,7 @@ import { Component, For, createMemo, Show } from "solid-js"
 import { TabItem, getStatusIndicator, getStatusColor } from "./TabItem"
 import type { AppEntry, AppStatus } from "../types"
 import type { Palette } from "../lib/palette"
+import { horizontalWindow } from "../lib/list-window"
 
 export interface TabListProps {
   entries: AppEntry[]
@@ -19,11 +20,11 @@ export interface TabListProps {
 }
 
 const HORIZONTAL_NAME_MAX = 12
+const ADD_W = 3 // trailing " + "
+const IND_W = 2 // each overflow-marker box ("‹ " / " ›" / "  ") — exactly 2 cols
 
 export const TabList: Component<TabListProps> = (props) => {
   // ── HORIZONTAL compact bar (height must be 1) ──────────────────────────────
-  // Memo hoisted to component scope so it's created once (not inside the render
-  // helper) and the orientation branch below can stay reactive.
   const horizontalSegments = createMemo(() =>
     props.entries.map((entry, index) => {
       const status = props.getStatus(entry.id)
@@ -40,6 +41,35 @@ export const TabList: Component<TabListProps> = (props) => {
     })
   )
 
+  // Reactive window: recomputes when entries / width / selection / active tab
+  // change, so navigating or resizing always keeps the active tab on-screen.
+  const horizontalView = createMemo(() => {
+    const segs = horizontalSegments()
+    // Segment column width: leading space + 1-col status dot + name + trailing
+    // space => name.length + 3.
+    const widths = segs.map((seg) => seg.name.length + 3)
+    // Active index to keep visible: when focused, follow the selection; else the
+    // active tab. Clamp / fall back to 0.
+    const rawActive = props.isFocused
+      ? props.selectedIndex
+      : segs.findIndex((s) => s.entry.id === props.activeTabId)
+    const active = Math.max(0, rawActive)
+    const avail0 = props.width - ADD_W
+    const total = widths.reduce((s, w) => s + w, 0)
+    const overflow = total > avail0
+    // In the overflow path at least one side is always hidden, and each marker
+    // box is exactly IND_W cols, so reserving 2*IND_W matches the rendered width.
+    const win = overflow
+      ? horizontalWindow(widths, avail0 - 2 * IND_W, active)
+      : { start: 0, end: segs.length, hiddenBefore: 0, hiddenAfter: 0 }
+    return {
+      overflow,
+      visible: segs.slice(win.start, win.end),
+      showLeft: win.hiddenBefore > 0,
+      showRight: win.hiddenAfter > 0,
+    }
+  })
+
   const renderHorizontal = () => (
     <box
       flexDirection="row"
@@ -48,7 +78,14 @@ export const TabList: Component<TabListProps> = (props) => {
       backgroundColor={props.theme.surface}
       overflow="hidden"
     >
-      <For each={horizontalSegments()}>
+      <Show when={horizontalView().overflow}>
+        <box height={1} backgroundColor={props.theme.surface}>
+          <text fg={props.theme.textDim} bg={props.theme.surface}>
+            {horizontalView().showLeft ? "‹ " : "  "}
+          </text>
+        </box>
+      </Show>
+      <For each={horizontalView().visible}>
         {(seg) => (
           <box
             flexDirection="row"
@@ -68,6 +105,13 @@ export const TabList: Component<TabListProps> = (props) => {
           </box>
         )}
       </For>
+      <Show when={horizontalView().overflow}>
+        <box height={1} backgroundColor={props.theme.surface}>
+          <text fg={props.theme.textDim} bg={props.theme.surface}>
+            {horizontalView().showRight ? " ›" : "  "}
+          </text>
+        </box>
+      </Show>
       {/* Trailing add affordance */}
       <box height={1} onMouseDown={props.onAddClick}>
         <text fg={props.theme.textDim}> + </text>

--- a/src/components/WindowList.tsx
+++ b/src/components/WindowList.tsx
@@ -1,6 +1,7 @@
-import { Component, For, Show } from "solid-js"
+import { Component, For, createMemo, Show } from "solid-js"
 import type { WindowState } from "../types"
 import type { Palette } from "../lib/palette"
+import { horizontalWindow } from "../lib/list-window"
 
 export interface WindowListProps {
   windows: WindowState[]
@@ -16,57 +17,95 @@ export interface WindowListProps {
 }
 
 const HORIZONTAL_MAX_TITLE = 12
+const ADD_W = 3 // trailing " + "
+const IND_W = 2 // each overflow-marker box ("‹ " / " ›" / "  ") — exactly 2 cols
 
 export const WindowList: Component<WindowListProps> = (props) => {
   const isHorizontal = () => props.orientation === "horizontal"
 
-  // --- HORIZONTAL rendering ---
-  const renderHorizontal = () => {
-    return (
-      <box
-        flexDirection="row"
-        width={props.width}
-        height={1}
-        backgroundColor={props.theme.surface}
-        overflow="hidden"
-      >
-        <For each={props.windows}>
-          {(window, index) => {
-            const isActive = () => window.id === props.activeWindowId
-            const isSelected = () => props.isFocused && index() === (props.selectedIndex ?? -1)
-            const highlighted = () => isActive() || isSelected()
-            const segBg = () => (highlighted() ? props.theme.surfaceAlt : props.theme.surface)
-            const segFg = () => (highlighted() ? props.theme.accent : props.theme.text)
-            const title = () => {
-              const raw = `${index() + 1}:${window.title}`
-              if (raw.length > HORIZONTAL_MAX_TITLE) {
-                return raw.slice(0, HORIZONTAL_MAX_TITLE - 1) + "…"
-              }
-              return raw
-            }
-            const segment = () => ` ${title()} `
-
-            return (
-              <box
-                height={1}
-                backgroundColor={segBg()}
-                onMouseDown={() => props.onSelect(window.id)}
-              >
-                <text fg={segFg()} bg={segBg()}>
-                  {highlighted() ? <b>{segment()}</b> : segment()}
-                </text>
-              </box>
-            )
-          }}
-        </For>
-
-        {/* Trailing add affordance */}
-        <box height={1} backgroundColor={props.theme.surface} onMouseDown={props.onAddClick}>
-          <text fg={props.theme.textDim} bg={props.theme.surface}>{" + "}</text>
-        </box>
-      </box>
-    )
+  const truncateTitle = (window: WindowState, index: number) => {
+    const raw = `${index + 1}:${window.title}`
+    if (raw.length > HORIZONTAL_MAX_TITLE) {
+      return raw.slice(0, HORIZONTAL_MAX_TITLE - 1) + "…"
+    }
+    return raw
   }
+
+  // --- HORIZONTAL rendering ---
+  // Reactive window: recomputes on windows / width / active-window change so the
+  // active window stays on-screen in the compact bar. (Window navigation tracks
+  // activeWindowId; there's no separate selection index for the window bar.)
+  const horizontalView = createMemo(() => {
+    const wins = props.windows
+    // Segment markup is ` ${title} ` => width = title.length + 2 (<= 14).
+    const widths = wins.map((w, i) => truncateTitle(w, i).length + 2)
+    const rawActive = wins.findIndex((w) => w.id === props.activeWindowId)
+    const active = Math.max(0, rawActive)
+    const avail0 = props.width - ADD_W
+    const total = widths.reduce((s, w) => s + w, 0)
+    const overflow = total > avail0
+    const win = overflow
+      ? horizontalWindow(widths, avail0 - 2 * IND_W, active)
+      : { start: 0, end: wins.length, hiddenBefore: 0, hiddenAfter: 0 }
+    return {
+      overflow,
+      start: win.start,
+      visible: wins.slice(win.start, win.end),
+      showLeft: win.hiddenBefore > 0,
+      showRight: win.hiddenAfter > 0,
+    }
+  })
+
+  const renderHorizontal = () => (
+    <box
+      flexDirection="row"
+      width={props.width}
+      height={1}
+      backgroundColor={props.theme.surface}
+      overflow="hidden"
+    >
+      <Show when={horizontalView().overflow}>
+        <box height={1} backgroundColor={props.theme.surface}>
+          <text fg={props.theme.textDim} bg={props.theme.surface}>
+            {horizontalView().showLeft ? "‹ " : "  "}
+          </text>
+        </box>
+      </Show>
+      <For each={horizontalView().visible}>
+        {(window, i) => {
+          const actualIndex = () => horizontalView().start + i()
+          const isActive = () => window.id === props.activeWindowId
+          const segBg = () => (isActive() ? props.theme.surfaceAlt : props.theme.surface)
+          const segFg = () => (isActive() ? props.theme.accent : props.theme.text)
+          const segment = () => ` ${truncateTitle(window, actualIndex())} `
+
+          return (
+            <box
+              height={1}
+              backgroundColor={segBg()}
+              onMouseDown={() => props.onSelect(window.id)}
+            >
+              <text fg={segFg()} bg={segBg()}>
+                {isActive() ? <b>{segment()}</b> : segment()}
+              </text>
+            </box>
+          )
+        }}
+      </For>
+      <Show when={horizontalView().overflow}>
+        <box height={1} backgroundColor={props.theme.surface}>
+          <text fg={props.theme.textDim} bg={props.theme.surface}>
+            {horizontalView().showRight ? " ›" : "  "}
+          </text>
+        </box>
+      </Show>
+
+      {/* Trailing add affordance */}
+      <box height={1} backgroundColor={props.theme.surface} onMouseDown={props.onAddClick}>
+        <text fg={props.theme.textDim} bg={props.theme.surface}>{" + "}</text>
+      </box>
+    </box>
+  )
 
   // --- VERTICAL rendering (unchanged) ---
   const visibleHeight = () => props.height - 2 // header band + footer add row

--- a/src/lib/list-window.test.ts
+++ b/src/lib/list-window.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { getVisibleWindowOffset } from "./list-window"
+import { getVisibleWindowOffset, horizontalWindow } from "./list-window"
 
 describe("getVisibleWindowOffset", () => {
   test("keeps early selections at the start", () => {
@@ -23,5 +23,88 @@ describe("getVisibleWindowOffset", () => {
 
   test("clamps to the final visible page", () => {
     expect(getVisibleWindowOffset(99, 20, 10)).toBe(10)
+  })
+})
+
+describe("horizontalWindow", () => {
+  test("returns the full range when everything fits", () => {
+    const widths = [4, 5, 6, 3]
+    const w = horizontalWindow(widths, 100, 2)
+    expect(w).toEqual({ start: 0, end: 4, hiddenBefore: 0, hiddenAfter: 0 })
+  })
+
+  test("returns the full range when total exactly equals available", () => {
+    const widths = [4, 5, 6, 3] // total 18
+    const w = horizontalWindow(widths, 18, 0)
+    expect(w).toEqual({ start: 0, end: 4, hiddenBefore: 0, hiddenAfter: 0 })
+  })
+
+  test("keeps the active item visible when active is in the middle", () => {
+    const widths = Array(20).fill(5) // 100 total
+    const active = 10
+    const w = horizontalWindow(widths, 30, active)
+    expect(active).toBeGreaterThanOrEqual(w.start)
+    expect(active).toBeLessThan(w.end)
+    // window must not exceed budget
+    const used = widths.slice(w.start, w.end).reduce((s, x) => s + x, 0)
+    expect(used).toBeLessThanOrEqual(30)
+    expect(w.hiddenBefore).toBe(w.start)
+    expect(w.hiddenAfter).toBe(20 - w.end)
+  })
+
+  test("keeps the active item visible when active is at index 0", () => {
+    const widths = Array(20).fill(5)
+    const w = horizontalWindow(widths, 30, 0)
+    expect(w.start).toBe(0)
+    expect(0).toBeLessThan(w.end)
+    expect(w.hiddenBefore).toBe(0)
+  })
+
+  test("keeps the active item visible when active is at index n-1", () => {
+    const widths = Array(20).fill(5)
+    const active = 19
+    const w = horizontalWindow(widths, 30, active)
+    expect(w.end).toBe(20)
+    expect(active).toBeGreaterThanOrEqual(w.start)
+    expect(active).toBeLessThan(w.end)
+    expect(w.hiddenAfter).toBe(0)
+  })
+
+  test("shows just the active item when it alone exceeds available", () => {
+    const widths = [5, 50, 5]
+    const w = horizontalWindow(widths, 10, 1)
+    expect(w).toEqual({ start: 1, end: 2, hiddenBefore: 1, hiddenAfter: 1 })
+  })
+
+  test("returns an empty window for empty widths", () => {
+    const w = horizontalWindow([], 10, 0)
+    expect(w).toEqual({ start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 })
+  })
+
+  test("handles uneven widths while keeping active visible", () => {
+    const widths = [2, 20, 3, 8, 4, 15, 6, 9] // total 67
+    const active = 4
+    const w = horizontalWindow(widths, 20, active)
+    expect(active).toBeGreaterThanOrEqual(w.start)
+    expect(active).toBeLessThan(w.end)
+    const used = widths.slice(w.start, w.end).reduce((s, x) => s + x, 0)
+    expect(used).toBeLessThanOrEqual(20)
+  })
+
+  test("clamps an out-of-range active index", () => {
+    const widths = Array(10).fill(5)
+    const w = horizontalWindow(widths, 12, 99)
+    // active clamps to 9, which must remain visible
+    expect(9).toBeGreaterThanOrEqual(w.start)
+    expect(9).toBeLessThan(w.end)
+  })
+
+  test("still returns a 1-item window when available is non-positive", () => {
+    const widths = [5, 6, 7]
+    const w = horizontalWindow(widths, 0, 1)
+    expect(w.start).toBe(1)
+    expect(w.end).toBe(2)
+    expect(1).toBeGreaterThanOrEqual(w.start)
+    expect(1).toBeLessThan(w.end)
   })
 })

--- a/src/lib/list-window.ts
+++ b/src/lib/list-window.ts
@@ -22,3 +22,58 @@ export function getVisibleWindowOffset(
 
   return clampedOffset
 }
+
+export interface HWindow {
+  start: number
+  end: number
+  hiddenBefore: number
+  hiddenAfter: number
+}
+
+/**
+ * Choose a contiguous run of items that fits within `available` columns and
+ * ALWAYS includes `active`. `widths[i]` is the rendered column width of item i.
+ * Greedily packs around `active`, alternating between adding to the left first
+ * then the right. If everything fits, returns the full range.
+ */
+export function horizontalWindow(
+  widths: number[],
+  available: number,
+  active: number
+): HWindow {
+  const n = widths.length
+  if (n === 0) {
+    return { start: 0, end: 0, hiddenBefore: 0, hiddenAfter: 0 }
+  }
+
+  const a = Math.max(0, Math.min(active, n - 1))
+
+  let total = 0
+  for (const w of widths) total += w
+  if (total <= available) {
+    return { start: 0, end: n, hiddenBefore: 0, hiddenAfter: 0 }
+  }
+
+  // Active is always shown, even if it alone exceeds `available`.
+  let start = a
+  let end = a + 1
+  let used = Math.min(widths[a], available)
+  let preferLeft = true
+
+  while (true) {
+    const canLeft = start > 0 && used + widths[start - 1] <= available
+    const canRight = end < n && used + widths[end] <= available
+    if (!canLeft && !canRight) break
+
+    if (canLeft && (preferLeft || !canRight)) {
+      used += widths[start - 1]
+      start--
+    } else if (canRight) {
+      used += widths[end]
+      end++
+    }
+    preferLeft = !preferLeft
+  }
+
+  return { start, end, hiddenBefore: start, hiddenAfter: n - end }
+}


### PR DESCRIPTION
**Fixes #17.** The horizontal (top/bottom) task bar rendered every tab/window in a single row with `overflow="hidden"` and no scrolling, so with many items in a narrow terminal the active one could clip off-screen.

## Change
- New pure helper `horizontalWindow(widths, available, active)` in `lib/list-window.ts` — greedily packs variable-width items around the active index and **always includes it**; returns the full range when everything fits. Unit-tested.
- Wired into the `TabList` and `WindowList` horizontal renderers with `‹ ›` overflow markers (shown only when items are actually hidden).

## Review fixes applied
Two Opus reviewers ran on the first pass (helper "solid"); they caught two HIGH integration bugs in the components, both fixed here:
- **Reactivity:** the window was computed as plain consts in the render fn, so the bar froze on navigation/resize — now a reactive `createMemo` (`<For each={view().visible}>`), so it re-windows live.
- **Marker width:** markers rendered 3 cols but only 2 were reserved, overflowing the row and clipping the `+` — markers are now exactly 2 cols, matching the reserved budget.
- Dropped a dead `selectedIndex` branch in WindowList (the window bar tracks `activeWindowId`).

## Testing
- `tsc` clean · `bun test` **71/71** (incl. new `horizontalWindow` cases) · build OK.
- Verified live (tmux, 14 tabs in a 90-col top bar): navigating to the **first / middle / last** tab keeps the active item on-screen with correct `‹`/`›` markers; rendered width stays ≤ terminal width (the `+` is never clipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
